### PR TITLE
fix(ci): Use repository variable for Firebase project ID

### DIFF
--- a/.github/GITHUB_ACTIONS_SETUP.md
+++ b/.github/GITHUB_ACTIONS_SETUP.md
@@ -69,16 +69,16 @@ Click **"CONTINUE"** then **"DONE"**
 - You'll use this entire JSON content as a GitHub secret
 - Delete the downloaded file after adding it to GitHub secrets
 
-### Step 2: Configure GitHub Repository Secrets
+### Step 2: Configure GitHub Repository Secrets and Variables
 
-Navigate to your GitHub repository:
+Navigate to your GitHub repository settings:
 1. Go to **Settings** → **Secrets and variables** → **Actions**
-2. Click **New repository secret**
-3. Add the following secrets:
 
 #### Required Secrets
 
 **Firebase Service Account:**
+
+Click **New repository secret** and add:
 ```
 Name: FIREBASE_SERVICE_ACCOUNT
 Value: <entire contents of the JSON file you downloaded>
@@ -100,9 +100,9 @@ Value: <entire contents of the JSON file you downloaded>
    }
    ```
 
-**Firebase Configuration (7 variables):**
+**Firebase Configuration Secrets (6 secrets):**
 
-These values are from your Firebase project settings (Project Settings → General → Your apps):
+Click **New repository secret** for each of these values from your Firebase project settings (Project Settings → General → Your apps):
 
 ```
 Name: VITE_FIREBASE_API_KEY
@@ -110,9 +110,6 @@ Value: <your-firebase-api-key>
 
 Name: VITE_FIREBASE_AUTH_DOMAIN
 Value: <your-project-id>.firebaseapp.com
-
-Name: VITE_FIREBASE_PROJECT_ID
-Value: salmoncow
 
 Name: VITE_FIREBASE_STORAGE_BUCKET
 Value: <your-project-id>.firebasestorage.app
@@ -128,6 +125,22 @@ Value: <your-measurement-id>
 ```
 
 **Note:** These Firebase config values are safe to expose client-side (they're public in your deployed app), but storing them as secrets keeps them out of public workflows and makes environment management easier.
+
+#### Required Variables
+
+**Firebase Project ID:**
+
+Click the **Variables** tab, then **New repository variable**:
+```
+Name: VITE_FIREBASE_PROJECT_ID
+Value: salmoncow
+```
+
+**Why use a variable instead of a secret?**
+- Project ID is non-sensitive and visible in URLs and public configuration
+- Variables are easier to view and update without re-entering the value
+- Workflows can use variables in output messages and URLs
+- Follows GitHub's best practice: secrets for sensitive data, variables for configuration
 
 ### Step 3: Verify Workflow Configuration
 

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -34,7 +34,7 @@ jobs:
           cat > .env << EOF
           VITE_FIREBASE_API_KEY=${{ secrets.VITE_FIREBASE_API_KEY }}
           VITE_FIREBASE_AUTH_DOMAIN=${{ secrets.VITE_FIREBASE_AUTH_DOMAIN }}
-          VITE_FIREBASE_PROJECT_ID=${{ secrets.VITE_FIREBASE_PROJECT_ID }}
+          VITE_FIREBASE_PROJECT_ID=${{ vars.VITE_FIREBASE_PROJECT_ID }}
           VITE_FIREBASE_STORAGE_BUCKET=${{ secrets.VITE_FIREBASE_STORAGE_BUCKET }}
           VITE_FIREBASE_MESSAGING_SENDER_ID=${{ secrets.VITE_FIREBASE_MESSAGING_SENDER_ID }}
           VITE_FIREBASE_APP_ID=${{ secrets.VITE_FIREBASE_APP_ID }}
@@ -50,7 +50,7 @@ jobs:
         with:
           repoToken: ${{ secrets.GITHUB_TOKEN }}
           firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
-          projectId: ${{ secrets.VITE_FIREBASE_PROJECT_ID }}
+          projectId: ${{ vars.VITE_FIREBASE_PROJECT_ID }}
           expires: 7d
 
       - name: Preview deployment info

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -33,7 +33,7 @@ jobs:
           cat > .env << EOF
           VITE_FIREBASE_API_KEY=${{ secrets.VITE_FIREBASE_API_KEY }}
           VITE_FIREBASE_AUTH_DOMAIN=${{ secrets.VITE_FIREBASE_AUTH_DOMAIN }}
-          VITE_FIREBASE_PROJECT_ID=${{ secrets.VITE_FIREBASE_PROJECT_ID }}
+          VITE_FIREBASE_PROJECT_ID=${{ vars.VITE_FIREBASE_PROJECT_ID }}
           VITE_FIREBASE_STORAGE_BUCKET=${{ secrets.VITE_FIREBASE_STORAGE_BUCKET }}
           VITE_FIREBASE_MESSAGING_SENDER_ID=${{ secrets.VITE_FIREBASE_MESSAGING_SENDER_ID }}
           VITE_FIREBASE_APP_ID=${{ secrets.VITE_FIREBASE_APP_ID }}
@@ -50,10 +50,10 @@ jobs:
           repoToken: ${{ secrets.GITHUB_TOKEN }}
           firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
           channelId: live
-          projectId: ${{ secrets.VITE_FIREBASE_PROJECT_ID }}
+          projectId: ${{ vars.VITE_FIREBASE_PROJECT_ID }}
 
       - name: Deployment summary
         run: |
           echo "✅ Deployment successful!"
-          echo "🌐 Live URL: https://${{ secrets.VITE_FIREBASE_PROJECT_ID }}.web.app"
-          echo "📊 View deployment: https://console.firebase.google.com/project/${{ secrets.VITE_FIREBASE_PROJECT_ID }}/hosting"
+          echo "🌐 Live URL: https://${{ vars.VITE_FIREBASE_PROJECT_ID }}.web.app"
+          echo "📊 View deployment: https://console.firebase.google.com/project/${{ vars.VITE_FIREBASE_PROJECT_ID }}/hosting"


### PR DESCRIPTION
## Summary
- Changed `VITE_FIREBASE_PROJECT_ID` from repository secret to repository variable
- Updated both deployment workflows to use `vars.VITE_FIREBASE_PROJECT_ID` instead of `secrets.VITE_FIREBASE_PROJECT_ID`
- Updated documentation to reflect the new configuration approach

## Changes
- **deploy-preview.yml**: Changed 2 references from `secrets.VITE_FIREBASE_PROJECT_ID` to `vars.VITE_FIREBASE_PROJECT_ID`
  - Environment file creation step (line 37)
  - Firebase deployment projectId parameter (line 53)
- **deploy-production.yml**: Changed 4 references from `secrets.VITE_FIREBASE_PROJECT_ID` to `vars.VITE_FIREBASE_PROJECT_ID`
  - Environment file creation step (line 36)
  - Firebase deployment projectId parameter (line 53)
  - Deployment summary URLs (lines 58-59)
- **GITHUB_ACTIONS_SETUP.md**: Updated Step 2 configuration instructions
  - Separated secrets and variables into distinct sections
  - Added explanation of why variables are preferred for project ID
  - Updated secret count from 7 to 6 (moved project ID to variables)

## Why This Change?
Following GitHub's best practices for secrets vs. variables:
- **Project ID is non-sensitive**: It's publicly visible in deployment URLs and Firebase config
- **Better usability**: Variables can be viewed without re-entering, making management easier
- **Workflow transparency**: Variables can be used in output messages and logs
- **Security clarity**: Reserves secrets for truly sensitive data (API keys, credentials)

## Guidance References
Following prompts:
- `core/deployment/deployment-principles.md` - CI/CD configuration best practices
- GitHub Actions best practices - Proper use of secrets vs. variables

## Test Plan
- [x] Verified all workflow file syntax is correct
- [x] Confirmed all references to `VITE_FIREBASE_PROJECT_ID` are updated
- [ ] Test preview deployment workflow on this PR
- [ ] Test production deployment workflow after merge
- [ ] Verify URLs in deployment summaries display correctly

## Checklist
- [x] No sensitive data committed
- [x] Follows documented patterns from `.prompts/`
- [x] Updated documentation (GITHUB_ACTIONS_SETUP.md)
- [x] CI checks should pass (no code changes, only configuration)

## Required Action Before Merge
⚠️ **Important**: The repository variable `VITE_FIREBASE_PROJECT_ID` must be created before merging this PR.

**Steps to configure:**
1. Go to **Settings** → **Secrets and variables** → **Actions**
2. Click the **Variables** tab
3. Click **New repository variable**
4. Name: `VITE_FIREBASE_PROJECT_ID`
5. Value: `salmoncow`
6. Click **Add variable**

Once the variable is added, this PR can be safely merged and deployments will work correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)