### PR TITLE
chore(hosting): add Cross-Origin-Opener-Policy header

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -75,6 +75,10 @@
             "value": "max-age=31536000; includeSubDomains"
           },
           {
+            "key": "Cross-Origin-Opener-Policy",
+            "value": "same-origin-allow-popups"
+          },
+          {
             "key": "Referrer-Policy",
             "value": "strict-origin-when-cross-origin"
           },


### PR DESCRIPTION
## Summary

- Adds `Cross-Origin-Opener-Policy: same-origin-allow-popups` to Firebase Hosting response headers.
- Silences two benign-but-noisy `firebase-auth` warnings during Google sign-in (`popup.ts:36` / `popup.ts:309` — "Cross-Origin-Opener-Policy policy would block the window.close{,d} call").
- Tightens our security posture: without an explicit COOP header, browsers default to `unsafe-none` in some contexts, giving no isolation at all.

## Changes

- `firebase.json` hosting headers: one new entry (4 lines)

## Why `same-origin-allow-popups` and not `same-origin`?

`same-origin` would give stricter isolation but breaks the `signInWithPopup` callback — our current warnings are because the browser is partway toward that stricter default. `same-origin-allow-popups` is the **Firebase-recommended posture** for apps using popup OAuth:

| | `unsafe-none` | `same-origin-allow-popups` | `same-origin` |
|-|-|-|-|
| Blocks cross-origin openers | ❌ | ✅ | ✅ |
| OAuth popups work | ✅ | ✅ | ⚠️ warnings |
| Defense vs Spectre-class attacks | ❌ | ✅ | ✅ |

The one thing it gives up vs `same-origin`: popups *we* open can still hold references to our window. Since the only popup we open is `accounts.google.com` via Firebase Auth, and we control that code path, the practical attack surface is near-zero.

## Testing

- [x] `firebase.json` is valid JSON (`node -e 'JSON.parse(require(\"fs\").readFileSync(\"firebase.json\"))'`)
- [ ] Post-merge: verify at https://www.salmoncow.com (or https://salmoncow.web.app) that `curl -I` shows the new header, and that devtools console no longer shows the two popup.ts warnings during sign-in

## Applies to all origins

Firebase Hosting attaches headers per-response, not per-origin, so this covers `www.salmoncow.com`, `salmoncow.com`, `salmoncow.web.app`, `salmoncow.firebaseapp.com`, and any preview channels equally.

## References

- [MDN: Cross-Origin-Opener-Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Opener-Policy)
- [Firebase Auth: browser COOP considerations](https://firebase.google.com/docs/auth/web/redirect-best-practices)
- [Chrome COOP/COEP explainer](https://web.dev/coop-coep/)