### PR TITLE
ci: deploy Firestore rules, indexes, and Cloud Functions from main

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -1,0 +1,98 @@
+name: Deploy Backend (Firestore + Functions)
+
+# SECURITY: This workflow uses FIREBASE_SERVICE_ACCOUNT for deployment.
+# - Service account requires additional IAM beyond the hosting workflow
+#   (firebaserules.admin, datastore.indexAdmin, cloudfunctions.developer,
+#   artifactregistry.writer, storage.admin, run.admin, and actAs on the
+#   project's compute default SA). See the PR body for the gcloud checklist.
+# - Changes to this file require review from CODEOWNERS.
+# - Hosting continues to deploy via deploy-production.yml; this workflow owns
+#   Firestore rules/indexes and Cloud Functions so backend and client can ship
+#   independently (path-filtered triggers + separate concurrency groups).
+
+# Initial rollout policy: workflow_dispatch ONLY.
+# Once two or three manual runs succeed end-to-end, add the push trigger
+# (commented block below) in a follow-up PR.
+
+on:
+  workflow_dispatch:
+    inputs:
+      targets:
+        description: 'Deploy targets (comma-separated subset of firestore,functions)'
+        required: true
+        default: 'firestore,functions'
+        type: string
+  # TODO(ci/deploy-backend): enable after initial manual runs succeed.
+  # push:
+  #   branches: [main]
+  #   paths:
+  #     - 'firestore.rules'
+  #     - 'firestore.indexes.json'
+  #     - 'functions/**'
+  #     - 'firebase.json'
+  #     - '.github/workflows/deploy-backend.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-backend-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy Firestore + Functions
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    env:
+      FIREBASE_CLI_VERSION: '15.15.0'
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: |
+            package-lock.json
+            functions/package-lock.json
+
+      - name: Install functions dependencies
+        run: npm ci --prefer-offline --prefix functions
+
+      - name: Build Cloud Functions
+        run: npm run build --prefix functions
+
+      - name: Install firebase-tools (pinned)
+        run: npm install -g firebase-tools@${FIREBASE_CLI_VERSION}
+
+      - name: Write service account credentials
+        env:
+          FIREBASE_SA_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
+        run: |
+          SA_KEY_FILE="${RUNNER_TEMP}/firebase-sa.json"
+          printf '%s' "$FIREBASE_SA_JSON" > "$SA_KEY_FILE"
+          chmod 600 "$SA_KEY_FILE"
+          echo "GOOGLE_APPLICATION_CREDENTIALS=${SA_KEY_FILE}" >> "$GITHUB_ENV"
+
+      - name: Deploy selected targets
+        run: |
+          firebase deploy \
+            --project "${{ vars.VITE_FIREBASE_PROJECT_ID }}" \
+            --only "${{ inputs.targets }}" \
+            --force \
+            --non-interactive
+
+      - name: Cleanup service account credentials
+        if: always()
+        run: rm -f "${GOOGLE_APPLICATION_CREDENTIALS:-/dev/null}"
+
+      - name: Deployment summary
+        run: |
+          echo "✅ Backend deploy complete (targets: ${{ inputs.targets }})"
+          echo "📊 Functions:  https://console.firebase.google.com/project/${{ vars.VITE_FIREBASE_PROJECT_ID }}/functions"
+          echo "📊 Firestore:  https://console.firebase.google.com/project/${{ vars.VITE_FIREBASE_PROJECT_ID }}/firestore/rules"


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/deploy-backend.yml` so CI can deploy Firestore rules, Firestore indexes, and Cloud Functions. Until now only Hosting shipped through `deploy-production.yml`.
- Gated behind `workflow_dispatch` for the first few runs; automatic `push: main` with path filter is staged as a commented block for a follow-up PR.
- Pins `firebase-tools@15.15.0` (exact), matching the maintainer's local CLI.
- **IAM bindings required by this workflow have been applied** (see "As-applied IAM" below). SA's pre-existing broader bindings (e.g. project-wide `roles/iam.serviceAccountUser`) were intentionally left alone to avoid disrupting parallel work — revisit in a future tightening PR.

## Design decisions

### 1. Separate workflow (not extending `deploy-production.yml`)
Chose to create `deploy-backend.yml` rather than extend the hosting workflow because:
- **Repo convention already splits by scope.** `deploy-production.yml` and `deploy-preview.yml` are already split; a third backend-focused file matches the pattern.
- **Independent rollouts.** Client bundles and backend rules/functions have different risk profiles and review cadences. Coupling them means every hosting push also redeploys functions (cold-starts, cost, noise).
- **Path filtering.** The future `push: main` trigger only fires when `firestore.rules`, `firestore.indexes.json`, `functions/**`, or `firebase.json` change.
- **Blast radius.** Hosting rollbacks via Firebase Console stay trivial; mixing a broken function deploy into a hosting workflow complicates that story.

### 2. `firebase-tools` pinning
Pinned to **exact** `15.15.0` (the maintainer's local CLI version). Firebase CLI has landed breaking changes between minors in the past (e.g. 2nd-gen function IAM behavior). Exact pin makes CI fully reproducible; Dependabot or a quarterly review bumps it in a one-line PR.

### 3. Safety rails for first runs
- **Manual-only trigger** for initial rollout (no `push`).
- `--non-interactive` prevents hangs on CLI prompts.
- `--force` is included so function deletions and IAM updates don't prompt, but the workflow is still human-triggered.
- Concurrency group `deploy-backend-${{ github.ref }}` with `cancel-in-progress: false` to avoid half-applied deploys.
- Credentials are written to `$RUNNER_TEMP`, `chmod 600`, and removed in a final cleanup step.

### 4. Tighter-than-documented IAM
Narrower scopes than the original proposal:
- `roles/artifactregistry.writer` bound at **repo level** (`us-central1/gcf-artifacts`) instead of project-wide.
- `roles/storage.objectAdmin` bound at **bucket level** on the three source/upload buckets instead of project-wide `roles/storage.admin`.
- `roles/run.developer` at project level instead of `roles/run.admin`. Trade-off: CI cannot `setIamPolicy` on Cloud Run, so any **new** callable function will need a one-time manual grant after its first deploy (`gcloud run services add-iam-policy-binding <svc> --region=us-central1 --member=allUsers --role=roles/run.invoker`). Existing `setuserrole` already has this binding.

## As-applied IAM (already executed by maintainer)

```bash
PROJECT=salmoncow
SA=github-actions-deploy@${PROJECT}.iam.gserviceaccount.com
PROJECT_NUMBER=$(gcloud projects describe "$PROJECT" --format='value(projectNumber)')
REGION=us-central1

# Project-level
gcloud projects add-iam-policy-binding $PROJECT --member=serviceAccount:$SA --role=roles/firebaserules.admin    --condition=None
gcloud projects add-iam-policy-binding $PROJECT --member=serviceAccount:$SA --role=roles/datastore.indexAdmin   --condition=None
gcloud projects add-iam-policy-binding $PROJECT --member=serviceAccount:$SA --role=roles/cloudfunctions.developer --condition=None
gcloud projects add-iam-policy-binding $PROJECT --member=serviceAccount:$SA --role=roles/run.developer          --condition=None

# Repo-scoped Artifact Registry
gcloud artifacts repositories add-iam-policy-binding gcf-artifacts \
  --location=$REGION --project=$PROJECT \
  --member=serviceAccount:$SA --role=roles/artifactregistry.writer

# Bucket-scoped Storage (3 buckets)
for BUCKET in \
  gcf-sources-${PROJECT_NUMBER}-${REGION} \
  gcf-v2-sources-${PROJECT_NUMBER}-${REGION} \
  gcf-v2-uploads-${PROJECT_NUMBER}.${REGION}.cloudfunctions.appspot.com ; do
  gcloud storage buckets add-iam-policy-binding gs://$BUCKET \
    --member=serviceAccount:$SA --role=roles/storage.objectAdmin
done
```

**Note on `iam.serviceAccountUser`:** the SA already carried this role at the project level, which transitively covers `actAs` on the compute default SA. Adding an SA-scoped binding as in the original checklist would have been a no-op, so it was skipped. Revoking the project-wide binding and replacing with an SA-scoped one is a future tightening follow-up.

### Verify
```bash
PROJECT=salmoncow
SA=github-actions-deploy@${PROJECT}.iam.gserviceaccount.com
gcloud projects get-iam-policy $PROJECT --flatten="bindings[].members" \
  --filter="bindings.members:serviceAccount:$SA" \
  --format="value(bindings.role)" | sort
```

Expected (at time of writing):
```
projects/salmoncow/roles/firebase.auth.domainmanager
roles/cloudfunctions.developer
roles/datastore.indexAdmin
roles/firebasehosting.admin
roles/firebaserules.admin
roles/iam.serviceAccountUser
roles/run.developer
roles/serviceusage.apiKeysViewer
```

## Known deploy-time hazard: callable `run.invoker` grant

Because we chose `roles/run.developer` over `roles/run.admin`, firebase-tools cannot auto-grant `allUsers → roles/run.invoker` on new callables. The existing `setUserRole` already has this binding (manually applied during its first deploy after a transient Cloud Build failure interrupted the automatic grant).

**When adding a new callable 2nd-gen function in the future**, expect the first CI deploy to either fail late with a Cloud Run IAM error or succeed with the callable returning `PERMISSION_DENIED`/`UNAUTHENTICATED` from the web app. Remediation (one-time per new service):

```bash
gcloud run services add-iam-policy-binding <service-name> \
  --region=us-central1 --member=allUsers --role=roles/run.invoker
```

## Test plan

- [x] Apply IAM bindings (done — see "As-applied IAM")
- [x] Verify bindings (done — output matches expected above)
- [ ] After merge: first `workflow_dispatch` with `targets=firestore` succeeds (smallest blast radius)
- [ ] Second run with `targets=functions` succeeds; verify `onUserCreate` and `setUserRole` still respond
- [ ] Confirm `setUserRole` still accepts calls from the web client
- [ ] Third run with `targets=firestore,functions` (the default) succeeds
- [ ] Follow-up PR: uncomment the `push: main` block with path filter
- [ ] Follow-up PR (optional): tighten the SA's pre-existing broad `roles/iam.serviceAccountUser` to SA-scoped binding

🤖 Generated with [Claude Code](https://claude.com/claude-code)