### PR TITLE
ci: add GitHub Actions test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,61 @@
+name: Test
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: test-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Run test suite
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: 'npm'
+          cache-dependency-path: |
+            package-lock.json
+            functions/package-lock.json
+
+      - name: Setup Java (required by Firestore emulator)
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Install root dependencies
+        run: npm ci --prefer-offline
+
+      - name: Install functions dependencies
+        run: npm ci --prefer-offline --prefix functions
+
+      - name: Build functions
+        run: npm run build --prefix functions
+
+      - name: Run test suite
+        run: npm run test
+
+      - name: Upload firestore debug log on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: firestore-debug-log
+          path: firestore-debug.log
+          if-no-files-found: ignore

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
+    env:
+      FIREBASE_CLI_VERSION: '15.15.0'
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -48,6 +51,9 @@ jobs:
 
       - name: Build functions
         run: npm run build --prefix functions
+
+      - name: Install firebase-tools (pinned)
+        run: npm install -g firebase-tools@${FIREBASE_CLI_VERSION}
 
       - name: Run test suite
         run: npm run test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: '17'
+          java-version: '21'
 
       - name: Install root dependencies
         run: npm ci --prefer-offline


### PR DESCRIPTION
## Summary

Adds `.github/workflows/test.yml`, a CI workflow that runs the full unit-test suite on every PR targeting `main` and on every push to `main`.

### What it runs

- `npm ci` at repo root and in `functions/`
- `npm run build --prefix functions` (TypeScript → `functions/lib/`; required because the emulator loads compiled JS)
- `npm install -g firebase-tools@15.15.0` (pinned; matches `deploy-backend.yml`)
- `npm run test` — chains:
  - `test:rules` → 41 Firestore security-rule tests under `firebase emulators:exec --only firestore`
  - `test:functions` → 18 Cloud Functions tests under `firebase emulators:exec --only auth,firestore,functions`
- On failure, uploads `firestore-debug.log` as an artifact for debugging rule compilation issues.

**First successful run on this PR: 41 + 18 = 59 tests passed.**

### Why

Tests currently only run locally. This workflow blocks regressions from slipping into `main` and gives PR authors fast feedback on rule/function changes before merge.

### Cost

Free tier. GitHub Actions allocates 2,000 minutes/month for private repos (unlimited for public); this job takes ~3–5 minutes per run. At typical PR volume this is well under the free allowance.

### Configuration notes

- **Two-lockfile cache**: `actions/setup-node` is configured with `cache-dependency-path` listing both `package-lock.json` and `functions/package-lock.json`. npm workspaces aren't used, so each `ci` step runs with `--prefix` (matching the pattern in `deploy-backend.yml`).
- **Java 21 (Temurin)**: required by `firebase-tools` 15.x. Older guidance said Java 17, but firebase-tools dropped <21 support — the emulator errors out with `firebase-tools no longer supports Java version before 21` otherwise.
- **firebase-tools installed in CI**: it's not a `devDependency` in either `package.json`; local dev relies on a global install. CI mirrors that with a pinned global install (same `FIREBASE_CLI_VERSION: '15.15.0'` as `deploy-backend.yml`).
- **Node 24**: matches the `engines` field in root `package.json`.
- **No reCAPTCHA key / no secrets**: the emulator skips App Check and the server relaxes enforcement under `FUNCTIONS_EMULATOR`. No `FIREBASE_SERVICE_ACCOUNT` / `VITE_FIREBASE_*` dependencies.
- **Concurrency** group per ref with `cancel-in-progress: true`, so rapid pushes to the same PR/branch don't pile up redundant runs.

### User action required

Branch-protection rules must be configured through the repo settings UI. After this PR merges and the workflow has a successful run on `main`:

1. Go to **Settings → Branches → Branch protection rules → `main`**.
2. Enable **Require status checks to pass before merging**.
3. Add **`Run test suite`** (the job name from `test.yml`) as a required check.

This can't be set via workflow file — GitHub only exposes it through the settings UI (or the API).

## Test plan

- [x] Workflow runs on this PR and the `Run test suite` job passes (green on commit 5e8c15a)
- [ ] After merge, workflow also runs on the push-to-main event
- [ ] Enable the required-status-check rule for `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)