### PR TITLE
fix(ui): bundle default-avatar.svg to fix avatar flicker

### DIFF
--- a/src/assets/images/placeholders/README.md
+++ b/src/assets/images/placeholders/README.md
@@ -1,43 +1,45 @@
 # Placeholder Images
 
-This directory contains fallback images used throughout the application when primary assets fail to load or are unavailable.
+Fallback images used throughout the application when primary assets fail to load or are unavailable.
 
 ## Available Placeholders
 
-### default-avatar.svg
-- **Purpose**: Fallback for user profile pictures when Google profile photo is unavailable or fails to load
-- **Used by**: UIModule (src/js/modules/ui.js)
-- **Dimensions**: 24x24 viewBox, scales to any size
-- **Colors**: Neutral gray (#f3f4f6, #9ca3af, #6b7280)
+### `default-avatar.svg`
+- **Purpose**: Fallback for user profile pictures when a Google profile photo is unavailable or fails to load.
+- **Used by**: `src/components/UserAvatar.js` (imported, bundled by Vite).
+- **Dimensions**: 24×24 viewBox, scales to any size.
+- **Colors**: Neutral gray (#f3f4f6, #9ca3af, #6b7280).
 - **Use cases**:
   - User has no Google profile photo
-  - Profile photo URL returns 404/429 error
-  - Network failure loading remote image
-  - User profile lists, comment sections, author cards
+  - Profile photo URL returns 404/429 / network failure
+  - User profile lists, comment sections, admin portal user table
 
 ## Usage Guidelines
 
-1. **Reference via path**: Use `/assets/images/placeholders/default-avatar.svg` (copied during build)
-2. **Do not embed**: Never copy this SVG into component code
-3. **Maintain consistency**: Use this placeholder for all user avatar fallbacks
-4. **Update documentation**: Document new usage locations above
+1. **Reference via `import`**, not a string literal. Example:
+   ```js
+   import defaultAvatarUrl from '../assets/images/placeholders/default-avatar.svg';
+   ```
+   Vite processes the import — small SVGs (<4 KB) are inlined as data URIs; larger ones are emitted to `dist/assets/` with a content hash.
 
-## Build Process
+   ❌ **Do not** reference via string path (e.g. `/assets/images/placeholders/default-avatar.svg`). Such paths bypass Vite's asset pipeline and, in production, are caught by the SPA rewrite (`**` → `/index.html`) and served as HTML — the image silently fails.
 
-Assets in `src/assets/` are copied to `public/assets/` during the build process by the `build:assets` npm script.
+2. **Single source**: only reference the placeholder from one web-component implementation (currently `UserAvatar`). Other modules should set the `photo` attribute on `<user-avatar>` and let the component handle the fallback internally.
+
+3. **Keep SVGs small** so Vite can inline them. Anything over ~4 KB becomes a separate network request.
 
 ## Modifying Placeholders
 
 When updating placeholder assets:
 1. Maintain semantic meaning (don't change purpose)
 2. Keep neutral colors for broad applicability
-3. Ensure accessibility (sufficient contrast ratios)
-4. Test across all usage locations
-5. Update this README with changes
+3. Ensure accessibility (sufficient contrast)
+4. Test: run `npm run build` and verify `dist/assets/js/index-*.js` contains the SVG as a data URI (inlined) or `dist/assets/*.svg` (emitted)
+5. Update this README
 
 ## Future Placeholders
 
 Consider adding:
-- `default-thumbnail.svg` - For article/video thumbnails
-- `image-not-found.svg` - Generic image error state
-- `video-not-found.svg` - Video error state
+- `default-thumbnail.svg` — for article/video thumbnails
+- `image-not-found.svg` — generic image error state
+- `video-not-found.svg` — video error state

--- a/src/components/UserAvatar.js
+++ b/src/components/UserAvatar.js
@@ -16,8 +16,13 @@
  * Architecture Note:
  *   Part of Phase 1 Web Components architecture.
  *   Follows asset reusability principles - single source for avatar fallback.
- *   See: .prompts/core/development/asset-reusability.md
  */
+
+// Imported (not referenced by string) so Vite includes it in the build
+// output. A string-literal path would be caught by the SPA rewrite and
+// served as index.html, breaking the fallback.
+import defaultAvatarUrl from '../assets/images/placeholders/default-avatar.svg';
+
 export class UserAvatar extends HTMLElement {
     static get observedAttributes() {
         return ['photo', 'alt', 'size'];
@@ -27,7 +32,12 @@ export class UserAvatar extends HTMLElement {
         this.render();
     }
 
-    attributeChangedCallback() {
+    attributeChangedCallback(name, oldValue, newValue) {
+        // Avoid unnecessary re-renders when a parent re-applies the same
+        // attributes (common when auth state fires multiple times). Each
+        // re-render destroys + recreates the <img>, forcing a fresh fetch
+        // and a brief flash of alt text.
+        if (oldValue === newValue) return;
         this.render();
     }
 
@@ -46,6 +56,9 @@ export class UserAvatar extends HTMLElement {
 
         const dimension = sizeMap[size] || sizeMap.medium;
 
+        // referrerpolicy=no-referrer helps Google's profile-photo CDN serve
+        // a cacheable response; sending a Referer header can trigger stricter
+        // caching behavior and intermittent failures.
         this.innerHTML = `
             <img
                 class="user-avatar"
@@ -54,6 +67,9 @@ export class UserAvatar extends HTMLElement {
                 width="${dimension}"
                 height="${dimension}"
                 data-size="${size}"
+                referrerpolicy="no-referrer"
+                loading="eager"
+                decoding="async"
             />
         `;
 
@@ -69,7 +85,7 @@ export class UserAvatar extends HTMLElement {
     }
 
     getDefaultAvatar() {
-        return '/assets/images/placeholders/default-avatar.svg';
+        return defaultAvatarUrl;
     }
 
     addStyles() {

--- a/src/modules/navigation.js
+++ b/src/modules/navigation.js
@@ -31,8 +31,9 @@ export class NavigationModule {
         this.isDropdownOpen = false;
         this.currentUser = null;
 
-        // Default avatar (reusable asset from placeholders)
-        this.defaultAvatarURL = '/assets/images/placeholders/default-avatar.svg';
+        // (Default avatar is handled internally by <user-avatar>; this
+        // module only sets the `photo` attribute. A prior string literal
+        // here was dead code — the fallback lives in UserAvatar.)
 
         // Event callbacks
         this.loginCallback = null;


### PR DESCRIPTION
## Summary

- **Root cause:** `default-avatar.svg` was referenced by string literal in `UserAvatar.js`, not imported. Vite skipped it during build. At runtime the path fell through Firebase Hosting's SPA rewrite (`**` → `/index.html`) and served `index.html` as the image — the browser couldn't render it, so the `<img>` showed its `alt` text. That's the "temporary text" users saw.
- **Fix:** `import defaultAvatarUrl from '../assets/images/placeholders/default-avatar.svg'`. Vite inlines it as a data URI (394 B, below the 4 KB threshold), so it's always in the bundle.
- Plus a handful of small UserAvatar quality-of-life improvements that reduce flicker on repeated re-renders.

## Changes

| File | Change |
|-|-|
| `src/components/UserAvatar.js` | Import SVG instead of hardcoded path; short-circuit `attributeChangedCallback` when value unchanged; add `referrerpolicy="no-referrer"`, `loading="eager"`, `decoding="async"` on the `<img>` |
| `src/modules/navigation.js` | Remove dead `this.defaultAvatarURL` field (never read; `<user-avatar>` handles fallback internally) |
| `src/assets/images/placeholders/README.md` | Document the import-not-string-path requirement and the SPA-rewrite gotcha that caused the bug |

## Why the flicker was happening

Compounding causes, in order of impact:

1. **Broken fallback asset** (fixed here): when `photoURL` was empty or failed, `<img>` fell back to `/assets/images/placeholders/default-avatar.svg` → 301 → HTML → render failure → alt text visible
2. **Aggressive re-renders** (partially addressed here): parent components like `AdminPortal` do `this.innerHTML = ...` on every state change, destroying and recreating `<user-avatar>` elements. Each recreation triggers a fresh image fetch. The `attributeChangedCallback` short-circuit helps where parents re-apply identical attributes; `referrerpolicy="no-referrer"` helps Google's CDN return cacheable responses
3. **Missing `photoURL` on pre-existing user docs** (not addressed here): users who signed in before `onUserCreate` existed have no Firestore doc with photoURL. For those rows, the admin portal passes an empty string. This PR's fix means they'll show a valid default avatar instead of alt text; the deeper fix (client-side reconciliation) is a separate change

## Testing

- [x] `npm run build` — bundle contains inlined data URI; no string-literal path remains (verified via `grep "data:image/svg+xml"`)
- [x] Full test suite: 59/59 green (41 rules + 18 functions)
- [ ] Post-merge: reload https://www.salmoncow.com admin portal — row avatars with no `photoURL` should show the gray-silhouette SVG, not alt text

## Out of scope (separate changes)

- Client-side reconciliation to populate `photoURL` on existing user docs
- AdminPortal refactor to avoid full-table re-renders on every state change