### PR TITLE
infra(functions): upgrade Cloud Functions runtime Node 20 → 22

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: |
             package-lock.json

--- a/firebase.json
+++ b/firebase.json
@@ -7,7 +7,7 @@
     {
       "source": "functions",
       "codebase": "default",
-      "runtime": "nodejs20",
+      "runtime": "nodejs22",
       "ignore": [
         "node_modules",
         ".git",

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -11,13 +11,13 @@
         "zod": "^3.23.8"
       },
       "devDependencies": {
-        "@types/node": "^20.14.0",
+        "@types/node": "^22.0.0",
         "firebase-functions-test": "^3.3.0",
         "typescript": "^5.5.3",
         "vitest": "^2.0.0"
       },
       "engines": {
-        "node": "20"
+        "node": "22"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2491,9 +2491,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.39",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
-      "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
+      "version": "22.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
+      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -4453,15 +4453,6 @@
       "optionalDependencies": {
         "@google-cloud/firestore": "^7.7.0",
         "@google-cloud/storage": "^7.7.0"
-      }
-    },
-    "node_modules/firebase-admin/node_modules/@types/node": {
-      "version": "22.19.17",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
-      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.21.0"
       }
     },
     "node_modules/firebase-functions": {

--- a/functions/package.json
+++ b/functions/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "main": "lib/index.js",
   "engines": {
-    "node": "20"
+    "node": "22"
   },
   "scripts": {
     "build": "tsc",
@@ -23,7 +23,7 @@
     "zod": "^3.23.8"
   },
   "devDependencies": {
-    "@types/node": "^20.14.0",
+    "@types/node": "^22.0.0",
     "firebase-functions-test": "^3.3.0",
     "typescript": "^5.5.3",
     "vitest": "^2.0.0"


### PR DESCRIPTION
Closes #29.

## Summary

- Upgrade Cloud Functions runtime from Node 20 → Node 22 before the **2026-04-30 deprecation deadline** (10 days out).
- Also closes a validation gap from the backend-CI rollout: the first Functions deploy via CI short-circuited with "no changes detected" and didn't exercise the AR image push or Cloud Run service update paths. This runtime change forces a real rebuild on merge, which in turn exercises the IAM bindings (`artifactregistry.writer`, bucket `storage.objectAdmin`, `run.developer`) that were only partially validated.

## Changes

| File | Change |
|-|-|
| `firebase.json` | `"runtime": "nodejs20"` → `"nodejs22"` |
| `functions/package.json` | `engines.node "20"` → `"22"`; `@types/node "^20.14.0"` → `"^22.0.0"` |
| `functions/package-lock.json` | Regenerated (only @types/node churn) |
| `.github/workflows/deploy-backend.yml` | `setup-node node-version: '20'` → `'22'` |

## Testing

- [x] `npm --prefix functions run build` — TS compiles clean with new `@types/node@22.19.17`
- [x] `npm run test` — 59/59 passing (41 rules + 18 functions). `@firebase/rules-unit-testing` emulator + `firebase-functions-test` harness both happy on the new type surface
- [ ] Post-merge: run `deploy-backend.yml` via `workflow_dispatch` with `targets=functions`. Expected: real rebuild (not "no changes"), AR image published, Cloud Run `setuserrole` revision shows a new container, `onUserCreate` redeployed as 1st gen on nodejs22
- [ ] Post-deploy: smoke-test via live site — sign in → `onUserCreate` fires; admin promotes another user → `setUserRole` callable executes. Both should behave identically to Node 20

## Deliberately out of scope

The `firebase-tools` CLI is flagging `firebase-functions` (6.0.1 → 7.x) and we know `firebase-admin` is also a major behind (12.7.0 → 13.x). Both are separate-PR candidates because they're major bumps with potentially breaking changes (`firebase-functions` v7 reportedly tightens v1 auth trigger deprecations, which we use for `onUserCreate`). Keeping this PR focused on the deadline-critical runtime change.

## Deadlines
- 2026-04-30 — deprecation
- 2026-10-30 — decommission