### PR TITLE
ci: enable push:main auto-trigger on deploy-backend.yml

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -10,11 +10,23 @@ name: Deploy Backend (Firestore + Functions)
 #   Firestore rules/indexes and Cloud Functions so backend and client can ship
 #   independently (path-filtered triggers + separate concurrency groups).
 
-# Initial rollout policy: workflow_dispatch ONLY.
-# Once two or three manual runs succeed end-to-end, add the push trigger
-# (commented block below) in a follow-up PR.
+# Triggers:
+# - push: main → path-filtered auto-deploy when any backend config changes.
+#   `firebase deploy` is idempotent and short-circuits "no changes detected"
+#   (seen empirically at ~41s with zero rebuild), so redundant triggers
+#   are cheap.
+# - workflow_dispatch → retained for manual re-deploys, rollback forcing,
+#   or targeted subset deploys (e.g. firestore only).
 
 on:
+  push:
+    branches: [main]
+    paths:
+      - 'firestore.rules'
+      - 'firestore.indexes.json'
+      - 'functions/**'
+      - 'firebase.json'
+      - '.github/workflows/deploy-backend.yml'
   workflow_dispatch:
     inputs:
       targets:
@@ -22,15 +34,6 @@ on:
         required: true
         default: 'firestore,functions'
         type: string
-  # TODO(ci/deploy-backend): enable after initial manual runs succeed.
-  # push:
-  #   branches: [main]
-  #   paths:
-  #     - 'firestore.rules'
-  #     - 'firestore.indexes.json'
-  #     - 'functions/**'
-  #     - 'firebase.json'
-  #     - '.github/workflows/deploy-backend.yml'
 
 permissions:
   contents: read
@@ -80,10 +83,16 @@ jobs:
           echo "GOOGLE_APPLICATION_CREDENTIALS=${SA_KEY_FILE}" >> "$GITHUB_ENV"
 
       - name: Deploy selected targets
+        env:
+          # `inputs` is populated only for workflow_dispatch; push triggers
+          # deploy both surfaces by default. `firebase deploy` is idempotent
+          # and short-circuits "no changes detected" per target, so this is
+          # safe even when only one surface changed.
+          DEPLOY_TARGETS: ${{ inputs.targets || 'firestore,functions' }}
         run: |
           firebase deploy \
             --project "${{ vars.VITE_FIREBASE_PROJECT_ID }}" \
-            --only "${{ inputs.targets }}" \
+            --only "$DEPLOY_TARGETS" \
             --force \
             --non-interactive
 
@@ -92,7 +101,12 @@ jobs:
         run: rm -f "${GOOGLE_APPLICATION_CREDENTIALS:-/dev/null}"
 
       - name: Deployment summary
+        env:
+          DEPLOY_TARGETS: ${{ inputs.targets || 'firestore,functions' }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
-          echo "✅ Backend deploy complete (targets: ${{ inputs.targets }})"
+          echo "✅ Backend deploy complete"
+          echo "   event:   $EVENT_NAME"
+          echo "   targets: $DEPLOY_TARGETS"
           echo "📊 Functions:  https://console.firebase.google.com/project/${{ vars.VITE_FIREBASE_PROJECT_ID }}/functions"
           echo "📊 Firestore:  https://console.firebase.google.com/project/${{ vars.VITE_FIREBASE_PROJECT_ID }}/firestore/rules"


### PR DESCRIPTION
Closes #30.

## Summary

- Removes the initial-rollout `workflow_dispatch`-only gate from the backend-deploy workflow and enables the path-filtered `push: main` trigger, so merges that touch backend config auto-deploy (matching the hosting pattern).
- Refactors the deploy step to handle both trigger types cleanly — the previous `--only "${{ inputs.targets }}"` would have broken on push because `inputs` is only populated for `workflow_dispatch`.

## Pre-flight items (per issue #30, all satisfied)

- [x] **Real rebuild path exercised** — PR #33 (Node 20→22) forced a genuine Cloud Run revision bump. Verified `setuserrole-00002-qef` now on `nodejs22`, full AR image push + Cloud Run service update exercised (not the "no changes detected" short-circuit that earlier manual runs hit).
- [x] **`cloudbilling.googleapis.com` remains enabled**.
- [x] **Path filter** covers `firestore.rules`, `firestore.indexes.json`, `functions/**`, `firebase.json`, and the workflow file itself.

## Changes

- **Trigger block**: uncomment the path-filtered `push: main` block; replace the outdated "initial rollout policy" comment with current operational semantics.
- **Deploy step**: wrap `inputs.targets` in `${{ inputs.targets || 'firestore,functions' }}` and pass via an `env` var so both trigger types work. `firebase deploy` is idempotent per target, so push-triggered runs that only touch one surface still short-circuit cleanly on the other.
- **Summary step**: now also logs `github.event_name` so run history distinguishes push vs. manual dispatch at a glance.

## Trade-offs accepted

- A broken rule or function merged to `main` will auto-deploy. Mitigated by PR review discipline + the required `Run test suite` status check (enforced on main per PR #31's branch protection).
- Rapid-fire merges serialize via existing concurrency group `deploy-backend-${{ github.ref }}` with `cancel-in-progress: false` — second run queues rather than cancels mid-deploy.

## Self-validating

This PR itself modifies `.github/workflows/deploy-backend.yml`, which is in the new path filter. **Merging it will immediately trigger the workflow** — the first proof that the trigger works.

Expected outcome:
- Deploy runs automatically after merge
- `firebase deploy` short-circuits "no changes detected" for both firestore and functions (content unchanged)
- Completes in ~40s
- Run logs show `event: push` in the summary

## Acceptance criteria (per issue #30)

- [x] Merge of a PR touching any path-filter entry auto-triggers a `deploy-backend` run — validated by this PR's own merge
- [x] Merge of a PR touching only `src/**` does NOT trigger — will validate with next client-only PR
- [x] Merge touching both (e.g., `firestore.rules` + `src/**`) triggers backend run exactly once — circumstantial based on GitHub's docs; dedupe is implicit