### PR TITLE
chore(specs): align speckit commands + anchor .specs/features/ directory

### DIFF
--- a/.claude/commands/speckit-plan.md
+++ b/.claude/commands/speckit-plan.md
@@ -4,14 +4,14 @@ Generate a detailed technical implementation plan for a feature specification.
 
 ## Prerequisites
 
-- Feature specification exists at `.specs/features/<feature-name>.md`
+- Feature specification exists at `.specs/features/<NNN-feature-name>/spec.md`
 - Constitutional constraints reviewed
 - Foundational patterns identified
 
 ## Workflow
 
 1. **Review Feature Spec**:
-   - Read `.specs/features/<feature-name>.md`
+   - Read `.specs/features/<NNN-feature-name>/spec.md`
    - Understand requirements and acceptance criteria
    - Identify constitutional constraints cited
 

--- a/.claude/commands/speckit-specify.md
+++ b/.claude/commands/speckit-specify.md
@@ -21,7 +21,9 @@ Create a feature requirement specification using spec-driven development princip
    - Check `.prompts/core/security/` for security requirements
    - Review `.prompts/platforms/firebase/` for Firebase implementation guidance
 
-4. **Create Feature Spec** at `.specs/features/<feature-name>.md`:
+4. **Create Feature Directory + Spec** at `.specs/features/<NNN-feature-name>/spec.md`
+   (three-digit numeric prefix keeps features sorted chronologically;
+    see `.specs/features/README.md` for the full directory convention):
    ```markdown
    # Feature Specification: <Feature Name>
 

--- a/.specs/features/README.md
+++ b/.specs/features/README.md
@@ -1,0 +1,24 @@
+# Active Feature Specs
+
+Per-feature specifications created via `/speckit-specify` live here while the
+feature is in flight. Each feature is a **directory**, not a single file:
+
+```
+.specs/features/<NNN-feature-name>/
+├── spec.md        # requirements, acceptance criteria, technical plan
+├── tasks.md       # ordered, committable task breakdown
+└── *.md           # optional: runbooks, notes, supplementary docs
+```
+
+The three-digit numeric prefix (e.g. `001-multi-user-rbac`) keeps features
+sorted chronologically and makes references stable across renames.
+
+**Lifecycle:**
+1. `/speckit-specify <feature-name>` — creates the directory + `spec.md`
+2. `/speckit-plan` — appends a **Technical Implementation Plan** section to `spec.md`
+3. `/speckit-tasks` — produces `tasks.md`
+4. `/speckit-implement` — executes against the plan
+5. After PR merge: `git mv .specs/features/<name>/ .specs/archive/<name>/`
+
+See the project's spec-kit overview at [../README.md](../README.md) for the
+portability rule that drove the archive/ vs features/ split.


### PR DESCRIPTION
Follow-up to #35 closing two small gaps found in the portability audit.

## Changes

1. **`.specs/features/README.md` (new)** — anchors the directory in git (otherwise `git` drops it since it's empty post-#35) and documents the directory-per-feature convention + `NNN-feature-name` numeric-prefix pattern + lifecycle through each speckit command.

2. **`.claude/commands/speckit-specify.md`** — path corrected from `.specs/features/<feature-name>.md` → `.specs/features/<NNN-feature-name>/spec.md` to match actual practice (see `.specs/archive/001-multi-user-rbac/` for the shape).

3. **`.claude/commands/speckit-plan.md`** — same path correction in prereqs and workflow step 1.

## Why now

- Without the README, anyone cloning `.specs/` to a new project would land with no `features/` directory at all — breaks the "where do new specs go" mental model.
- The slash commands described a single-file spec convention; every feature this project has actually shipped used a directory. The mismatch would confuse any future feature kick-off.

## Scope

Docs only. Zero code changes, no tests affected, no production behavior changes.