### PR TITLE
fix(tests): stabilize onUserCreate test against emulator-trigger race

### DIFF
--- a/functions/tests/helpers.ts
+++ b/functions/tests/helpers.ts
@@ -39,17 +39,25 @@ export function nextUid(prefix = 'u'): string {
 /**
  * Create a Firebase Auth user in the emulator. Idempotent — swallows the
  * "uid-already-exists" error so helpers can be called multiple times safely.
+ *
+ * In CI the real onUserCreate trigger is loaded in the Functions emulator
+ * and auto-fires on createUser. That trigger races with the test's direct
+ * `wrapped(userRecord)` invocation. To keep the resulting users/{uid} doc
+ * deterministic regardless of which write lands last, callers that also
+ * pass a userRecord to `wrapped` must mirror its fields here.
  */
 export async function ensureAuthUser(
     uid: string,
     email?: string,
     displayName?: string,
+    photoURL?: string,
 ): Promise<void> {
     try {
         await auth.createUser({
             uid,
             email: email ?? `${uid}@example.com`,
             displayName: displayName ?? uid,
+            ...(photoURL ? { photoURL } : {}),
         });
     } catch (e) {
         const err = e as { code?: string; errorInfo?: { code?: string } };

--- a/functions/tests/onUserCreate.test.ts
+++ b/functions/tests/onUserCreate.test.ts
@@ -26,6 +26,7 @@ describe('onUserCreate auth trigger', () => {
             uid,
             `${uid}@example.com`,
             'New User',
+            'https://example.com/avatar.png',
         );
         const userRecord = ft.auth.makeUserRecord({
             uid,


### PR DESCRIPTION
## Summary
- The Test workflow failed on [main post-#37](https://github.com/salmoncow/salmoncow/actions/runs/24794089479) with `expected null to be 'https://example.com/avatar.png'` at [functions/tests/onUserCreate.test.ts:46](functions/tests/onUserCreate.test.ts:46).
- Root cause is a latent race, not the vitest 3 upgrade itself — vitest 3's faster scheduling just exposed it. CI was always the only environment set up to trigger it.

## Root cause
In CI, the workflow runs `npm run build --prefix functions` before tests, which emits `functions/lib/index.js`. When `firebase emulators:exec --only auth,firestore,functions` starts, the **real** `onUserCreate` v1 auth trigger is loaded into the Functions emulator. From then on, every call to `auth.createUser(...)` auto-fires that trigger asynchronously.

The failing test does two things:
1. Calls `ensureAuthUser(uid, email, 'New User')` — creates an Auth user with **no** `photoURL`. The emulator-loaded trigger fires and writes `users/{uid}` with `photoURL: null`.
2. Calls `wrapped(userRecord)` directly via `firebase-functions-test`, passing a `userRecord` that **does** have `photoURL: 'https://example.com/avatar.png'`. This is an in-process handler invocation that writes `users/{uid}` with the expected `photoURL`.

Both writes target the same doc with `{ merge: true }`. Whichever lands last wins on the `photoURL` field. On my local machine `wrapped()` consistently wins. On the slower CI runner the emulator trigger wins (emulator's setUserRole tests take ~3100ms in CI vs ~600ms local), so `photoURL` ends up `null` and the assertion trips.

Locally, the race doesn't exist at all for me because I'd been running `npm run test:functions` without first building — the emulator log even prints `functions/lib/index.js does not exist, can't deploy Cloud Functions`, meaning no trigger is loaded and only the `wrapped()` invocation writes the doc. That's why the PR #37 pre-merge check passed locally but failed in CI.

## Fix
Minimal: make the Auth user's fields match the test's mock `userRecord` so both converging writes produce identical data. Whichever trigger invocation wins the race, the resulting doc is the same.

- [functions/tests/helpers.ts](functions/tests/helpers.ts) — `ensureAuthUser` gains an optional `photoURL` arg.
- [functions/tests/onUserCreate.test.ts](functions/tests/onUserCreate.test.ts:29) — the `creates a users/{uid} doc with defaults` test passes the matching `photoURL`.
- No production code changed. The `{ merge: true }` idempotency and race-handling in [functions/src/onUserCreate.ts](functions/src/onUserCreate.ts) remain correct under real-world conditions (Firebase Auth only fires onCreate once per uid; no retries in practice that would overlap a manual call).

## Changes
- Add optional `photoURL` parameter to `ensureAuthUser` in [functions/tests/helpers.ts](functions/tests/helpers.ts).
- Thread `'https://example.com/avatar.png'` through the assertive test case in [functions/tests/onUserCreate.test.ts](functions/tests/onUserCreate.test.ts).
- Jsdoc on `ensureAuthUser` now documents the race so future callers that add a `wrapped()` invocation know to mirror fields.

## Testing
- [x] `npm test` → 59/59 pass locally (41 rules + 18 functions), with functions built so the real trigger IS loaded — same setup as CI.
- [x] No CJS deprecation warning regressed.
- [ ] Reviewer: confirm GitHub Actions Test workflow goes green on this PR before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)