### PR TITLE
build(deps): upgrade firebase-functions 6.6.0 → 7.2.5

### DIFF
--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -7,7 +7,7 @@
       "name": "functions",
       "dependencies": {
         "firebase-admin": "^12.7.0",
-        "firebase-functions": "^6.0.1",
+        "firebase-functions": "^7.2.5",
         "zod": "^3.23.8"
       },
       "devDependencies": {
@@ -4548,9 +4548,9 @@
       }
     },
     "node_modules/firebase-functions": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-6.6.0.tgz",
-      "integrity": "sha512-wwfo6JF+N7HUExVs5gUFgkgVGHDEog9O+qtouh7IuJWk8TBQ+KwXEgRiXbatSj7EbTu3/yYnHuzh3XExbfF6wQ==",
+      "version": "7.2.5",
+      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-7.2.5.tgz",
+      "integrity": "sha512-K+pP0AknluAguLRbD96hibyXbnOgwnvd4hkExWdGrxnNCLoj8LBFj08uvJYxyvhsCgYzQumrUaHBW4lsXKSiRg==",
       "license": "MIT",
       "dependencies": {
         "@types/cors": "^2.8.5",
@@ -4563,10 +4563,24 @@
         "firebase-functions": "lib/bin/firebase-functions.js"
       },
       "engines": {
-        "node": ">=14.10.0"
+        "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "firebase-admin": "^11.10.0 || ^12.0.0 || ^13.0.0"
+        "@apollo/server": "^5.2.0",
+        "@as-integrations/express4": "^1.1.2",
+        "firebase-admin": "^11.10.0 || ^12.0.0 || ^13.0.0",
+        "graphql": "^16.12.0"
+      },
+      "peerDependenciesMeta": {
+        "@apollo/server": {
+          "optional": true
+        },
+        "@as-integrations/express4": {
+          "optional": true
+        },
+        "graphql": {
+          "optional": true
+        }
       }
     },
     "node_modules/firebase-functions-test": {

--- a/functions/package.json
+++ b/functions/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "firebase-admin": "^12.7.0",
-    "firebase-functions": "^6.0.1",
+    "firebase-functions": "^7.2.5",
     "zod": "^3.23.8"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

- Bumps `firebase-functions` from `^6.0.1` (resolved 6.6.0) → `^7.2.5` in `functions/package.json`.
- Clears the emulator's deprecation warning: _"package.json indicates an outdated version of firebase-functions. Please upgrade using npm install --save firebase-functions@latest"_ that printed on every `npm test` run.
- No source changes. v7's breaking changes don't touch this codebase.

## v6 → v7 breaking-change audit

| v7.0.0 breaking change | Affects this repo? |
|---|---|
| Drop Node 16 (min is now 18) | No — functions pin is Node 22 (`engines.node: "22"`), unchanged by PR #33. |
| Remove `functions.config()` API | No — unused (grep clean across `functions/src/**`). |
| TS 5 + ES2022 target | No — already on TS 5.5.3. |
| `onRequest` emulator error behavior | No — `onRequest` is not used. |
| v1 `Event` → `LegacyEvent` rename | No — the `Event` type is not imported. |

Imports remain valid:
- `firebase-functions/v2/https` → `onCall`, `HttpsError` (used in `setUserRole`, `lastOwnerGuard`, `rateLimit`)
- `firebase-functions/v1` → `functionsV1.auth.user().onCreate` (used in `onUserCreate`)

Security posture preserved: App Check (`enforceAppCheck`), zod input validation, rate limiting, and the last-owner guard inside a transaction are all untouched.

## Dependency impact

`firebase-functions@7` peerDeps accept `firebase-admin@^11 || ^12 || ^13`. We're on `^12.7.0` — **no cascading bump to `firebase-admin`.**

## Files touched

- `functions/package.json`
- `functions/package-lock.json`

No source files in `functions/src/**` or `functions/tests/**` required migration.

## Test plan

- [x] `npm run build` in `functions/` → clean (TS compile with new types)
- [x] `npm test` from repo root → **59/59 pass** (41 rules + 18 functions)
- [x] `firebase-functions` outdated-version warning no longer appears in emulator output
- [ ] Verify on deploy: no runtime regressions in `onUserCreate` / `setUserRole` after this lands on `main` and deploy-backend workflow runs

Note: the task description referenced "72 tests (13 unit + 41 rules + 18 functions)"; the 13 unit tests are the theme tests that live on the in-flight `feat/dark-mode-theme` branch, not `main`. On `main` the full suite is 59 tests, and all 59 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)