### PR TITLE
feat(theme): add user-selectable dark mode with Firestore persistence

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -5,10 +5,39 @@ name: Deploy Preview
 # - Changes to this file require review from CODEOWNERS
 # - Service account follows least privilege principle (limited to necessary permissions only)
 
+# Triggers:
+# - pull_request: main → path-filtered so only changes that actually affect
+#   the built site spawn a preview channel. Spec/docs/test-only PRs skip the
+#   preview (and its 7-day-expiring channel + service-account roundtrip).
+#
+# The allowlist below mirrors what Vite bakes into `dist/`:
+#   - src/**              — entry HTML, JS modules, CSS, component assets
+#   - public/**           — served verbatim (vite.config.js publicDir)
+#   - package.json, lock  — dep bumps that change what builds
+#   - vite.config.js      — build config
+#   - firebase.json       — hosting rewrites/headers
+#   - .firebaserc         — project alias (if ever repointed)
+#   - THIS workflow file  — so changes to the trigger itself get validated
+#
+# Deliberately NOT in the allowlist:
+#   - .specs/**, .prompts/**, *.md at root → docs
+#   - tests/**, vitest*.config.*           → CI-only, not shipped
+#   - functions/**, firestore.rules/.indexes.json → backend (deploy-backend.yml)
+#   - scripts/**, tsconfig.json, .nvmrc    → dev tooling, not build inputs
+
 on:
   pull_request:
     branches:
       - main
+    paths:
+      - 'src/**'
+      - 'public/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'vite.config.js'
+      - 'firebase.json'
+      - '.firebaserc'
+      - '.github/workflows/deploy-preview.yml'
 
 permissions:
   checks: write

--- a/.specs/features/002-dark-mode-theme/spec.md
+++ b/.specs/features/002-dark-mode-theme/spec.md
@@ -1,0 +1,438 @@
+# Feature Specification: Dark Mode Theme
+
+**Version**: 1.0.0
+**Created**: 2026-04-22
+**Status**: Draft
+
+---
+
+## I. Overview
+
+Apply a user-selectable colour theme (light / dark / system) across the SalmonCow web app and persist the authenticated user's choice in their Firestore `users/{uid}` profile document.
+
+The preference **data model and persistence layer already exist**:
+- [src/types/user-profile.js:13](../../../src/types/user-profile.js) — `UserPreferences.theme: 'light' | 'dark' | 'system'`, default `'system'`
+- [src/components/UserPortal.js:146](../../../src/components/UserPortal.js) — theme `<select>` already rendered and emits `preference-change`
+- [src/modules/user-portal.js:105](../../../src/modules/user-portal.js) — change handler already forwards to `UserProfileService.updatePreferences()`
+- [src/repositories/firestore-user-profile-repository.js:99](../../../src/repositories/firestore-user-profile-repository.js) — `update()` already persists the `preferences` map
+
+**What this feature adds** is everything *downstream* of that persisted value: the runtime that reads it, applies it to the DOM, respects the OS preference when `system` is selected, prevents a light-mode flash on cold load, and the CSS-token refactor that makes "dark mode" actually mean something visually.
+
+---
+
+## II. Constitutional Constraints
+
+Citing [.specs/constitution.md](../../constitution.md).
+
+**Current phase (§II.1)** — UI is **Phase 1 (Vanilla Web Components)**; we must not introduce a framework or styling lib. CSS custom properties + `[data-theme]` attribute on `<html>` is the idiomatic Phase 1 approach.
+
+**Quality standards**:
+- **§III.2 Security** — Theme data is non-sensitive; no new attack surface. Existing rules already restrict `users/{uid}` writes to the owner and reject client writes to `role`/`roleChangedAt` (verified in [firestore-user-profile-repository.js:37](../../../src/repositories/firestore-user-profile-repository.js)). `preferences.theme` is already permitted.
+- **§III.3 Performance** — FCP target <1.5s p95. Initial theme **must** be applied before first paint (inline `<script>` in `index.html` reading from `localStorage`) to avoid a flash of light-mode content (FOUC).
+- **§III.4 Code Quality** — Conventional commits, PR-only changes.
+
+**Forbidden patterns avoided (§IV.2)**:
+- No new Firestore reads introduced — the theme piggybacks on the existing `getOrCreateProfile()` fetch during auth state change.
+- No uncleaned `onSnapshot()` listeners. The `matchMedia` listener for system-preference changes **is** new and must be torn down on sign-out / module destroy.
+- No client-side filtering, no unbounded reads.
+
+**Cost (§VI)** — Zero additional Firestore read/write budget. Theme writes reuse the existing `updatePreferences` path (~1 write per user-initiated theme change).
+
+**Evolution triggers not crossed** — this feature adds **one** module (`theme.js`) and does not move any domain into a new phase.
+
+---
+
+## III. User Stories
+
+**US-1 — Signed-in user picks a theme and it sticks across sessions/devices.**
+As an authenticated user, when I change the Theme dropdown in my profile to "Dark", the app switches to dark colours immediately and the choice is stored in my Firestore profile so signing in on another browser shows the same theme.
+
+**US-2 — Signed-in user follows the OS.**
+As an authenticated user, when I leave Theme set to "System", the app tracks my OS-level `prefers-color-scheme`: if I toggle macOS dark mode mid-session, the app follows without a reload.
+
+**US-3 — Anonymous visitor sees a consistent theme.**
+As an unauthenticated visitor, the app respects my OS `prefers-color-scheme` on first visit. If I later sign in and I have a stored preference, that preference takes over on the next auth state callback.
+
+**US-4 — No flash of wrong theme on cold load.**
+As any user reloading the page with dark mode active, I do **not** see a split-second light-mode flash before the theme applies.
+
+---
+
+## IV. Acceptance Criteria
+
+**Runtime behaviour**
+- AC-1. Setting `<html data-theme="dark">` visibly switches every surface (body, cards, text, buttons, nav, toasts, admin portal, user portal) to a dark palette. No element retains a hardcoded light-mode colour.
+- AC-2. Changing the Theme dropdown in the User Portal updates the DOM within one animation frame, persists to Firestore, and survives a hard reload.
+- AC-3. When `preferences.theme === 'system'`, the applied theme matches `window.matchMedia('(prefers-color-scheme: dark)').matches` and updates live when the OS setting changes.
+- AC-4. On cold load, a brief inline `<script>` in `index.html` reads a `localStorage` key (`salmoncow.theme`) and sets `<html data-theme>` *before* stylesheets evaluate; no FOUC is visible in a throttled-3G profile.
+- AC-5. On sign-out, the applied theme reverts to the `localStorage`-cached value (or `system` if none), and the theme module unsubscribes any live listeners.
+
+**Data layer**
+- AC-6. Firestore `users/{uid}.preferences.theme` is written only via the existing `UserProfileService.updatePreferences()` path — no new repository method is introduced.
+- AC-7. `localStorage` cache is updated whenever the applied theme changes, for any reason (user selection, profile load, system-preference change while in `system` mode).
+- AC-8. Invalid stored values (anything not `'light'|'dark'|'system'`) are ignored and treated as `'system'`.
+
+**Testing**
+- AC-9. Unit tests cover: resolving `'system'` → `'light'|'dark'` via mocked `matchMedia`; applying/removing the DOM attribute; `localStorage` read/write; invalid-value fallback; subscription teardown.
+- AC-10. The existing Firestore rules test suite is re-run unchanged and still passes (no rules surface touched).
+
+**Non-functional**
+- AC-11. The feature adds no new npm dependency.
+- AC-12. The feature adds **one** new module file (`src/modules/theme.js`) and refactors existing CSS/component styles to reference tokens; module count stays ≤ 9 (well under the 10-module Phase-2-testing trigger).
+
+---
+
+## V. Architecture Approach
+
+**Module boundary** — One new module, `src/modules/theme.js`, exposing a `ThemeModule` with:
+- `init()` — reads `localStorage`, applies initial theme, starts `matchMedia` listener if the resolved preference is `system`.
+- `applyPreference(theme)` — applies one of `'light'|'dark'|'system'`, updates `localStorage`, re-wires `matchMedia` subscription as needed.
+- `onProfileLoaded(profile)` / `onSignOut()` — called by `App` / `UserPortalModule` at the existing auth-state hooks in [main.js:278](../../../src/main.js).
+- `destroy()` — idempotent teardown of `matchMedia` listener.
+
+**Dependency direction** (§II.3) — `ThemeModule` depends only on `window` APIs and is called from `App` (presentation layer). It does **not** import `UserProfileService` or Firestore SDK; it receives theme values as plain strings from the existing profile-change hook. This keeps the module pure and trivial to unit-test.
+
+**Integration points**:
+- `src/main.js` — instantiate `ThemeModule` before auth state listener wires up; call `theme.onProfileLoaded(profile)` from inside the existing `setupAuthStateListener` → `userPortal.handleAuthStateChange` flow (add a parallel call, do not re-plumb through the portal).
+- `index.html` — inline pre-paint script (see §III.3) to set `<html data-theme>` from `localStorage` before CSS loads.
+- `src/styles/main.css` — introduce `:root { --color-bg: ...; --color-fg: ...; ... }` and a `[data-theme="dark"] { ... }` override block; migrate hardcoded `#f3f4f6`, `#1f2937`, etc. to tokens.
+- Component inline styles (`UserPortal`, `UserAvatar`, `StatusBadge`, `AdminPortal`, `ToastContainer`, `LoadingSpinner`, `navigation.css`) — migrate hardcoded colours to the same tokens. Component styles attach to `document.head` once (existing pattern), so tokens cascade naturally into light-DOM children.
+
+**Pattern references**:
+- [.prompts/core/architecture/modular-architecture-principles.md](../../../.prompts/core/architecture/modular-architecture-principles.md) — single-responsibility module; no cross-cutting infrastructure.
+- [.prompts/core/architecture/code-structure.md](../../../.prompts/core/architecture/code-structure.md) — `modules/` is the right layer (application logic, not infra).
+- [.prompts/core/development/asset-reusability.md](../../../.prompts/core/development/asset-reusability.md) — design tokens over duplicated colour literals.
+
+---
+
+## VI. Security Requirements
+
+- Only the owner of `users/{uid}` can write `preferences` — already enforced by existing Firestore rules (verified by existing test suite). No rules change.
+- `preferences.theme` passes the repo's `sanitizeUpdate` because it's not in `FORBIDDEN_CLIENT_FIELDS`. No change to that allowlist.
+- Validate the incoming string on the client: `updatePreferences` is called only with values from a closed `<option>` set, but the `ThemeModule` **must** also whitelist (`['light','dark','system']`) before applying — defence in depth, matches §III.2 ("input validation at all boundaries").
+- `localStorage` value is untrusted input on read (user could tamper). Treat it exactly like any external input: validate against the same whitelist; fall back to `'system'` on anything else.
+- No `innerHTML` injection: the module manipulates `document.documentElement.dataset.theme` only — no HTML strings, no XSS surface.
+
+**Pattern references**:
+- [.prompts/core/security/security-principles.md](../../../.prompts/core/security/security-principles.md) — input validation at boundaries.
+- [.prompts/platforms/firebase/firebase-security.md](../../../.prompts/platforms/firebase/firebase-security.md) — rules already cover this data shape.
+
+---
+
+## VII. Firebase Implementation
+
+**No new Firestore surface.** The feature consumes `preferences.theme` via the existing profile fetch and writes it via the existing `updatePreferences()` call.
+
+- **Reads**: 0 new. Theme is extracted from the same `getOrCreateProfile` result that already loads on sign-in.
+- **Writes**: 1 per user-initiated theme change (existing `updatePreferences` path). No batching needed.
+- **Listeners**: 0 new. Do **not** add an `onSnapshot` for cross-device live theme sync — not worth the quota and listener-cleanup burden for a rarely-changing preference. Next-sign-in sync is sufficient (US-1 spec).
+- **Cost budget**: Negligible. Worst case at 1,000 DAU with 1 theme change/user/month ≈ 1,000 writes/month, vs. the 20k/day Blaze free quota (§VI.1).
+
+**Pattern references**:
+- [.prompts/platforms/firebase/firebase-best-practices.md](../../../.prompts/platforms/firebase/firebase-best-practices.md) — prefer one-shot reads over listeners for rarely-changing data.
+- [.prompts/platforms/firebase/firebase-finops.md](../../../.prompts/platforms/firebase/firebase-finops.md) — 0-read designs beat cached-read designs.
+
+---
+
+## VIII. Testing Requirements
+
+Per constitution §III.1 (70/20/10 pyramid, ≥80% overall, 100% for critical paths). Theme is **not** a critical path; standard coverage applies.
+
+**Unit tests** (new — `tests/unit/modules/theme.test.js` or similar, matching existing test layout):
+- Applies `light`/`dark` to `document.documentElement.dataset.theme` correctly.
+- Resolves `system` via mocked `matchMedia` for both dark-true and dark-false OS states.
+- Re-applies when the mocked `matchMedia` change event fires, only while mode is `system`.
+- Stops reacting to `matchMedia` after switching away from `system`.
+- Reads `localStorage` on `init()`; falls back to `'system'` on missing/invalid values.
+- Writes `localStorage` on every applied change.
+- `destroy()` removes the `matchMedia` listener (verify the mock `removeEventListener` is called).
+
+**Integration smoke** (optional, manual is acceptable per §III.1 Phase 1 stance):
+- Load app signed-out → verify OS preference respected.
+- Sign in → verify Firestore value overrides; change dropdown → verify immediate DOM update + Firestore write.
+- Hard reload → verify no FOUC (QA with Network throttle = Slow 3G in DevTools).
+- Cross-browser: Chrome, Safari (WebKit's `matchMedia` legacy API nuance).
+
+**Rules tests** — Unchanged; no rules surface modified. Re-run to confirm no regression.
+
+**Pattern references**:
+- [.prompts/core/testing/testing-principles.md](../../../.prompts/core/testing/testing-principles.md) — AAA pattern, descriptive names.
+- [.prompts/platforms/firebase/firebase-testing.md](../../../.prompts/platforms/firebase/firebase-testing.md) — emulator / rules regression workflow.
+
+---
+
+## IX. Out of Scope
+
+To keep this feature focused and avoid scope creep:
+- **Accent-colour customisation / full theming API** — dark/light only; the existing `--brand-primary` stays as-is (or gets one dark-mode tweak if contrast demands it).
+- **Per-route themes** or scheduled/automatic switching (e.g. "dark after sunset") — not requested.
+- **High-contrast / accessibility-preset themes** — out of scope; WCAG AA contrast on both light and dark is in scope.
+- **Cross-device live sync via `onSnapshot`** — explicitly rejected in §VII.
+- **Animated theme transitions** — a `transition: background-color 150ms` on `body` is nice-to-have; leave to implementation judgement, do not spec.
+
+---
+
+## X. References
+
+**Constitutional constraints cited**:
+- §II.1 — UI Phase 1 (Vanilla Web Components) — no framework introduction
+- §II.3 — Modularity (single-responsibility, dependency direction)
+- §III.2 — Security (input validation at all boundaries)
+- §III.3 — Performance (FCP <1.5s, FOUC prevention)
+- §IV.2 — Forbidden patterns (no uncleaned listeners; no new unnecessary `onSnapshot`)
+- §VI.1 — Blaze free quotas (no new read/write pressure)
+
+**Foundational patterns referenced**:
+- [.prompts/core/architecture/modular-architecture-principles.md](../../../.prompts/core/architecture/modular-architecture-principles.md)
+- [.prompts/core/architecture/code-structure.md](../../../.prompts/core/architecture/code-structure.md)
+- [.prompts/core/security/security-principles.md](../../../.prompts/core/security/security-principles.md)
+- [.prompts/core/testing/testing-principles.md](../../../.prompts/core/testing/testing-principles.md)
+- [.prompts/core/development/asset-reusability.md](../../../.prompts/core/development/asset-reusability.md)
+- [.prompts/platforms/firebase/firebase-best-practices.md](../../../.prompts/platforms/firebase/firebase-best-practices.md)
+- [.prompts/platforms/firebase/firebase-finops.md](../../../.prompts/platforms/firebase/firebase-finops.md)
+- [.prompts/platforms/firebase/firebase-security.md](../../../.prompts/platforms/firebase/firebase-security.md)
+
+**Existing code touchpoints**:
+- [src/types/user-profile.js](../../../src/types/user-profile.js) — data model (unchanged)
+- [src/components/UserPortal.js](../../../src/components/UserPortal.js) — theme selector (unchanged behaviour)
+- [src/modules/user-portal.js](../../../src/modules/user-portal.js) — change handler (unchanged)
+- [src/main.js](../../../src/main.js) — integration point for `ThemeModule.init()` and profile-loaded hook
+- [src/styles/main.css](../../../src/styles/main.css) — token refactor site
+- [index.html](../../../index.html) — inline pre-paint script
+
+---
+
+## XI. Technical Implementation Plan
+
+### XI.1 Architecture
+
+**Module shape** — one new file, `src/modules/theme.js`, exporting a `ThemeModule` class. Pure DOM + `window` APIs; no Firebase imports; no coupling to `UserProfileService`. Receives plain strings at its public methods.
+
+```
+ThemeModule
+├── init()                            → read localStorage, apply initial theme, start system watcher if resolved === 'system'
+├── applyPreference(theme: string)    → whitelist-validate; set dataset + localStorage; start/stop system watcher
+├── onProfileLoaded(profile)          → delegates to applyPreference(profile?.preferences?.theme)
+├── onSignOut()                       → re-resolve from localStorage (keep last-known; don't force 'system')
+├── getResolvedTheme(): 'light'|'dark'→ expose for tests; computed from stored pref + matchMedia
+└── destroy()                         → remove matchMedia listener; idempotent
+```
+
+**Dependency flow** (respects §II.3 Application → Service → Infrastructure):
+```
+main.js  ──instantiates──▶  ThemeModule
+main.js  ──onAuth──▶  UserPortalModule.handleAuthStateChange  ──(new)──▶  theme.onProfileLoaded(profile)
+UserPortal <select>  ──preference-change──▶  UserPortalModule  ──updatePreferences──▶  Firestore
+                                                                   └──(new)──▶  theme.applyPreference(value)    // apply optimistically
+```
+
+Key choice: `ThemeModule` **is called from both sides** — optimistically on user action (instant UI response) *and* authoritatively after Firestore confirms via the next profile fetch / state callback. Because the module is idempotent, double-apply is a no-op. This avoids having to add a new observer on `UserProfileService.onStateChange` (the service's existing callback, [user-profile-service.js:179](../../../src/services/user-profile-service.js)) if we don't want to — but using `onStateChange` is the cleanest wiring and the plan picks it (see XI.8 step 5).
+
+### XI.2 Data Layer
+
+**No Firestore schema change.** `users/{uid}.preferences.theme` already exists (§I citations).
+
+**Queries** — none new. Reads piggyback on existing `getOrCreateProfile` (1 get per sign-in, cached 5 min by [user-profile-service.js:27](../../../src/services/user-profile-service.js)).
+
+**Writes** — reuses existing `UserProfileService.updatePreferences()` → `repository.update()` → `updateDoc({ preferences: { theme } }, merge via service pattern)`.
+> Note: current `updatePreferences({ theme: 'dark' })` sends `{ preferences: { theme: 'dark' } }` which on Firestore **replaces** the `preferences` map. Since all preference UI goes through the same path and the service layer spreads the full object, this is already fine for the in-memory `preferences` object — but the service should write a **merged** preferences map so an older tab writing `{ theme }` doesn't clobber `{ emailNotifications }`. Verify [user-profile-service.js:121](../../../src/services/user-profile-service.js) merges against current cached profile before writing. **This is a latent bug separate from the feature; flag it but do NOT fix it here** — out of scope, candidate for a follow-up task.
+
+**Rules** — no change. Existing [firestore.rules](../../../firestore.rules) already permits the owner to write non-forbidden fields on their own `users/{uid}` doc; `preferences.theme` is not forbidden.
+
+### XI.3 UI Components (Phase 1: Vanilla Web Components)
+
+**No new components.** The existing `<user-portal>` already renders the theme `<select>`. No component API change.
+
+**CSS token layer** (new) — introduce a shared token set at `:root` and override at `[data-theme="dark"]`. The existing `navigation.css` already defines `:root { --brand-primary, --dropdown-bg, ... }`; **extend that pattern** rather than creating a parallel system. Split into two concerns:
+
+1. **Semantic surface tokens** (new, in `src/styles/main.css` `:root`):
+   ```css
+   :root {
+     --surface-bg:        #f3f4f6;
+     --surface-elevated:  #ffffff;
+     --surface-border:    #e5e7eb;
+     --text-primary:      #1f2937;
+     --text-secondary:    #6b7280;
+     --text-tertiary:     #9ca3af;
+     --focus-ring:        rgba(214, 110, 79, 0.2);
+     --shadow-card:       0 4px 20px rgba(0, 0, 0, 0.08);
+     --error-fg:          #c62828;
+     --toggle-track:      #d1d5db;
+   }
+   [data-theme="dark"] {
+     --surface-bg:        #0b1220;
+     --surface-elevated:  #111827;
+     --surface-border:    #1f2937;
+     --text-primary:      #f3f4f6;
+     --text-secondary:    #9ca3af;
+     --text-tertiary:     #6b7280;
+     --focus-ring:        rgba(214, 110, 79, 0.35);
+     --shadow-card:       0 4px 20px rgba(0, 0, 0, 0.45);
+     --error-fg:          #f87171;
+     --toggle-track:      #374151;
+   }
+   ```
+   Exact values are the *implementation's* decision — contrast must meet WCAG AA (§IX scope statement). These are a starting palette, not a contract.
+
+2. **Brand tokens stay as-is**; `--brand-primary` is the salmon accent and remains constant across themes (only the surfaces/text invert).
+
+**Migration targets** (hardcoded → token):
+| File | Hardcoded values to replace |
+|---|---|
+| [src/styles/main.css:9](../../../src/styles/main.css) | `background: #f3f4f6` → `var(--surface-bg)` |
+| [src/components/UserPortal.js:242](../../../src/components/UserPortal.js) | `white`, `rgba(0,0,0,.08)`, `#1f2937`, `#6b7280`, `#9ca3af`, `#e5e7eb`, `#f3f4f6`, `#c62828`, `#d1d5db`, `#374151` → tokens |
+| [src/assets/styles/navigation.css:22](../../../src/assets/styles/navigation.css) | `--dropdown-bg: #ffffff` → `var(--surface-elevated)`, `--dropdown-border: #e5e7eb` → `var(--surface-border)`, `--dropdown-text: #333333` → `var(--text-primary)`, `--dropdown-hover-bg: #f3f4f6` → `var(--surface-bg)` (keep the nav bar itself branded = salmon in both themes) |
+| `src/components/LoadingSpinner.js`, `StatusBadge.js`, `UserAvatar.js`, `AdminPortal.js`, `ToastContainer.js` | audit each `addStyles()` method, same treatment |
+
+**The `<select>` element** in UserPortal — ensure the SVG arrow data-URI and `background-color: white` both switch. Either wrap both in tokens or set `color-scheme: light dark` on `:root`/`[data-theme="dark"]` so native form controls adapt automatically (preferred — one CSS line, eliminates per-input styling).
+
+### XI.4 Pre-Paint FOUC Prevention
+
+Add a short inline `<script>` in [src/index.html:7](../../../src/index.html) `<head>`, **before** any stylesheet is referenced (Vite injects the CSS link during build, but the inline script runs first since it's in the HTML source):
+
+```html
+<script>
+  (function () {
+    try {
+      var v = localStorage.getItem('salmoncow.theme');
+      if (v !== 'light' && v !== 'dark' && v !== 'system') v = 'system';
+      var resolved = v === 'system'
+        ? (matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light')
+        : v;
+      document.documentElement.dataset.theme = resolved;
+    } catch (_) { /* localStorage disabled; accept light default */ }
+  })();
+</script>
+```
+
+Rationale:
+- **Inline + synchronous**: no network round-trip, no module import, no parse deferral. Runs before render.
+- **Whitelist-on-read**: tampered localStorage values fall back to `system` (AC-8).
+- **Try/catch**: private-mode Safari can throw on `localStorage.getItem`; swallow and accept the default.
+- **~300 bytes minified**: inside any reasonable perf budget; does not affect FCP measurably.
+
+Keep the script hand-written and minimal — do **not** import a module here (would defer to after HTML parse → FOUC reintroduced).
+
+### XI.5 Security Implementation
+
+Cross-ref §VI of this spec. Concretely:
+
+1. **Whitelist on every boundary**:
+   - Inline pre-paint script (above): whitelists before `dataset.theme =`.
+   - `ThemeModule.applyPreference(v)`: whitelists `v` against `['light','dark','system']`; invalid → no-op + `console.warn`.
+   - `UserPortalModule.handlePreferenceChange('theme', v)`: already forwards to `updatePreferences`; since the `<select>` is closed-set and same-origin, no additional validation needed *at the service layer*, but `ThemeModule` validation still applies upstream.
+2. **Firestore rules**: no change. Owner-only write is already enforced.
+3. **No `innerHTML`**: `ThemeModule` only touches `document.documentElement.dataset.theme` and `localStorage`. No XSS surface.
+4. **Pre-paint script audit**: the only sink is `dataset.theme`, and the assigned value is whitelisted. No string concat into HTML / eval / Function.
+
+### XI.6 Testing Strategy
+
+**State of test harness** — `tests/rules/*.test.ts` uses vitest via the Firestore emulator exec wrapper ([package.json:13](../../../package.json)). There is **no existing JS-module unit-test setup** — `vitest` is installed but only runs `tests/rules/`. This feature adds a small plain-JS unit layer.
+
+**Two-part test plan**:
+
+1. **New: `tests/unit/modules/theme.test.js`** with a minimal `vitest.config.js` addition or a new `test:unit` script:
+   ```json
+   "test:unit": "vitest run tests/unit"
+   ```
+   and chain it into the existing `test` script: `"test": "npm run test:rules && npm run test:functions && npm run test:unit"`.
+
+   **Test cases** (AAA, mocked `matchMedia` + `localStorage` via `jsdom`):
+   - `init()` with no localStorage → applies `'system'`-resolved theme.
+   - `init()` with `localStorage = 'dark'` → applies `'dark'`; does not attach `matchMedia` listener.
+   - `init()` with `localStorage = 'system'` + OS dark → applies `'dark'`; attaches listener.
+   - `init()` with `localStorage = 'garbage'` → applies `'system'`-resolved; localStorage rewritten? (**decide once**: plan says leave the bad value, it will be corrected on the next valid `applyPreference`).
+   - `applyPreference('dark')` → `documentElement.dataset.theme === 'dark'`, `localStorage.salmoncow.theme === 'dark'`, listener detached.
+   - `applyPreference('system')` → listener attached; firing mock change flips `dataset.theme`.
+   - `applyPreference('invalid')` → no-op, no throw.
+   - `destroy()` → `matchMedia().removeEventListener` called; subsequent mock change events are ignored.
+   - `onProfileLoaded({ preferences: { theme: 'light' } })` → equivalent to `applyPreference('light')`.
+   - `onProfileLoaded(null)` → no-op (signed-out guard).
+
+2. **Existing rules tests** — run unchanged. Expect 100% pass. No rules surface touched.
+
+3. **Manual QA checklist** (signed off in PR description per constitution §V.1 step 7):
+   - [ ] Signed-out cold load, OS=light → light theme visible, no flash.
+   - [ ] Signed-out cold load, OS=dark → dark theme visible, no flash.
+   - [ ] Sign in with stored `theme='dark'` → dark theme persists across refresh.
+   - [ ] Change OS setting while `theme='system'` → app follows without reload.
+   - [ ] Change OS setting while `theme='light'` → app does **not** change (AC-3 negative case).
+   - [ ] Toggle dropdown to `dark` → Firestore `users/{uid}.preferences.theme === 'dark'` (inspect emulator).
+   - [ ] Two browsers: change in one, sign in on the other → second picks up new value on next sign-in.
+   - [ ] DevTools Slow-3G cold load → no FOUC.
+   - [ ] Safari + Chrome parity.
+   - [ ] Keyboard focus rings still visible on dark.
+
+### XI.7 Performance Considerations
+
+- **Bundle size** — `ThemeModule` ~1 KB minified; inline pre-paint script ~300 B in HTML. No new npm deps. Total page-weight delta: under 1.5 KB gzip.
+- **Firestore quota** — 0 additional reads, ~1 write per user per preference change. At 1,000 DAU × 1 change/month = 1,000 writes/month vs. Blaze free 600k writes/month — **0.16%** of budget. Stays well within §VI.1 targets.
+- **Runtime** — setting `dataset.theme` triggers style recalc on the `<html>` subtree; benchmark target <8 ms on mid-range mobile. Only runs on init and on genuine preference change.
+- **Caching** — the 5-min service cache in `UserProfileService` already covers the read path. `localStorage` acts as a first-paint cache; it is authoritative until Firestore confirms (up to one profile fetch later).
+
+### XI.8 Implementation Steps (ordered)
+
+1. **CSS token layer** — extend `src/styles/main.css` with `:root` semantic tokens + `[data-theme="dark"]` overrides; add `color-scheme: light dark;` under the dark block for native controls. Do **not** change any component styles yet — tokens should degrade to the current palette when unreferenced.
+2. **Inline pre-paint script** — add `<script>` at the top of `<head>` in [src/index.html:7](../../../src/index.html) per XI.4.
+3. **Create `src/modules/theme.js`** — implement `ThemeModule` per XI.1 shape. Keep it ~100 lines; resist abstraction.
+4. **Wire `ThemeModule` in `main.js`** — instantiate before `setupAuthStateListener` in [src/main.js:55](../../../src/main.js); call `theme.init()` there.
+5. **Subscribe to profile state changes** — in `main.js`, after `this.profileService` exists (line 174), register `this.profileService.onStateChange((profile) => this.theme.onProfileLoaded(profile))`. This handles both sign-in (profile set) and sign-out (profile null → no-op).
+6. **Optimistic apply** — in [src/modules/user-portal.js:108](../../../src/modules/user-portal.js) `handlePreferenceChange`, when `key === 'theme'`, call `this.theme.applyPreference(value)` **before** awaiting the Firestore write. Pass `theme` into `UserPortalModule`'s constructor via DI (new optional arg; falsy = no-op).
+7. **Migrate CSS literals → tokens** — sweep the files listed in XI.3 migration table. One file per commit; each commit visually regression-tested in light mode (should look identical) and in dark mode (should look coherent).
+8. **Add `test:unit` script + `tests/unit/modules/theme.test.js`** — install any missing `jsdom` dep if vitest doesn't pull it transitively (`@vitest/ui` not needed). Update the top-level `test` script to chain.
+9. **Manual QA** per XI.6 checklist.
+10. **PR** — summary, per-AC evidence (screenshots of light + dark), guidance references section citing §II.1, §III.2, §III.3.
+
+### XI.9 Files to Create / Modify
+
+**Create**:
+- `src/modules/theme.js` (~100 LOC)
+- `tests/unit/modules/theme.test.js` (~150 LOC, mocked DOM)
+
+**Modify**:
+- `src/index.html` — add inline pre-paint `<script>` (§XI.4)
+- `src/styles/main.css` — add token layer + dark override (§XI.3)
+- `src/assets/styles/navigation.css` — remap existing tokens onto shared semantic tokens (§XI.3 table)
+- `src/components/UserPortal.js` — `addStyles()` hardcoded colours → tokens
+- `src/components/AdminPortal.js` — same
+- `src/components/LoadingSpinner.js` — same
+- `src/components/StatusBadge.js` — same
+- `src/components/UserAvatar.js` — same (if any hardcoded colours present; audit)
+- `src/components/ToastContainer.js` — same (toast backgrounds especially; ensure success/error/info still read well on dark)
+- `src/main.js` — instantiate `ThemeModule`, wire to `onStateChange` (§XI.8 steps 4–5)
+- `src/modules/user-portal.js` — accept optional `theme` DI, call `applyPreference` optimistically (§XI.8 step 6)
+- `package.json` — add `test:unit` script; extend `test` script
+
+**Not modified** (explicit):
+- `firestore.rules` — no rules change needed.
+- `src/types/user-profile.js` — data model is already correct.
+- `src/repositories/firestore-user-profile-repository.js` — no repo change; `preferences.theme` flows through existing `update()`.
+- `src/services/user-profile-service.js` — **not modified in this feature**, though the latent merge-vs-overwrite concern in XI.2 deserves a follow-up task.
+- `functions/**` — no Cloud Function surface touched.
+
+### XI.10 Estimated Complexity
+
+| Dimension | Estimate |
+|---|---|
+| New files | 2 (`theme.js`, `theme.test.js`) |
+| Modified files | ~10 (CSS + components + html + main + package) |
+| New LOC | ~250 (module + tests + token CSS) |
+| Churn LOC | ~80 (literal→token sweeps) |
+| New Firestore reads | 0 |
+| New Firestore writes | ~1 per user-initiated change (existing path) |
+| New npm deps | 0 (jsdom may already be in vitest's tree; verify) |
+| Risk of regression | Low — CSS-token migration is the only surface that could break layout; each file migrated in isolation |
+| Effort | ~1 focused day to land cleanly (module + tokens + component sweep + tests + QA) |
+
+### XI.11 Plan Validation (Constitution checklist)
+
+- [x] **Phase respected** — UI stays Phase 1 (Vanilla WC), no framework added.
+- [x] **Approved patterns** — design tokens (asset-reusability), modular single-responsibility (modular-architecture), boundary validation (security-principles), one-shot reads over listeners (firebase-best-practices).
+- [x] **Forbidden patterns avoided** — no unbounded reads; no uncleaned listeners (matchMedia is cleaned in `destroy()`); no new `onSnapshot`; no premature abstraction (single module, no plugin system).
+- [x] **Quality standards addressed** — FOUC mitigation for §III.3; boundary whitelist for §III.2; unit tests per §III.1 proportional-to-criticality.
+- [x] **Cost constraints** — 0 new reads, negligible writes; well under §VI.1 Blaze free quotas.
+- [x] **Metric impact** — adds 1 module (8 → 9), still under the 10-module Phase 2 testing trigger.
+
+---
+
+**Next step**: `/speckit-tasks` to produce the ordered, committable task breakdown in `tasks.md`.

--- a/.specs/features/002-dark-mode-theme/tasks.md
+++ b/.specs/features/002-dark-mode-theme/tasks.md
@@ -1,0 +1,146 @@
+# Task Breakdown: Dark Mode Theme
+
+**Feature**: 002-dark-mode-theme
+**Spec**: [spec.md](./spec.md) (Sections I–XI)
+**Created**: 2026-04-22
+**Status**: Ready for implementation
+
+Each numbered group below maps to one logical phase in §XI.8 of the spec and is a **prospective commit**. Commit only when all boxes in a group are checked and the group's validation gate passes.
+
+**Complexity legend**: S = <30min · M = 30min–2h · L = >2h
+**AC refs**: acceptance criteria from §IV of the spec.
+
+**Sequencing rule**: Groups 1 and 2 are **invisible refactors** (no runtime behaviour change because nothing sets `<html data-theme>` yet). Group 3 is the first commit that *activates* dark mode. This ordering means any revert up through Group 2 is zero-risk to light-mode users.
+
+---
+
+## Group 1 — CSS Token Foundation
+
+**Goal**: Semantic surface tokens at `:root` plus `[data-theme="dark"]` override block live in `main.css`; `navigation.css` tokens remapped onto the shared set. Zero runtime behaviour change — light mode renders pixel-identically because nothing sets the theme attribute yet.
+**Commit message**: `feat(theme): add :root semantic tokens and dark override layer`
+**AC**: AC-1 (groundwork only)
+
+- [ ] **1.1 (S)** Create branch `feat/dark-mode-theme` from `main` (per `git-conventions`).
+- [ ] **1.2 (M)** Extend [src/styles/main.css](../../../src/styles/main.css): add the semantic token block per §XI.3 (`--surface-bg`, `--surface-elevated`, `--surface-border`, `--text-primary`, `--text-secondary`, `--text-tertiary`, `--focus-ring`, `--shadow-card`, `--error-fg`, `--toggle-track`) inside `:root`, and the matching `[data-theme="dark"] { ... }` block. Include `color-scheme: light dark;` on the dark block for native control adaptation.
+- [ ] **1.3 (S)** Update the existing `body { background: #f3f4f6 }` in `main.css` to `var(--surface-bg)`. (Sole token use in this group — everything else happens in Group 2.)
+- [ ] **1.4 (M)** Remap [src/assets/styles/navigation.css:22](../../../src/assets/styles/navigation.css) dropdown tokens onto the shared semantic set per §XI.3 migration table: `--dropdown-bg → var(--surface-elevated)`, `--dropdown-border → var(--surface-border)`, `--dropdown-text → var(--text-primary)`, `--dropdown-text-secondary → var(--text-secondary)`, `--dropdown-hover-bg → var(--surface-bg)`. The nav bar background itself stays `--brand-primary` (brand, not surface) in both themes.
+- [ ] **1.5 (S)** `npm run build` completes without errors. Visual diff: `npm run dev:app` and eyeball every page — must look identical to `main`. *(Validation gate.)*
+
+**Validation**: Zero visual regression in light mode; build clean.
+
+---
+
+## Group 2 — Component Style Sweeps
+
+**Goal**: Migrate hardcoded colours in the six Web Components' `addStyles()` methods to the shared tokens. Still no runtime behaviour change — only substitutions that map 1:1 to current light-mode values.
+**Commit message**: `refactor(components): use surface tokens in component styles for theme support`
+**AC**: AC-1 (full surface coverage)
+
+- [ ] **2.1 (M)** [src/components/UserPortal.js:242](../../../src/components/UserPortal.js) — sweep per §XI.3 migration table: `white` → `var(--surface-elevated)`, `rgba(0,0,0,.08)` shadow → `var(--shadow-card)`, `#1f2937` → `var(--text-primary)`, `#6b7280` → `var(--text-secondary)`, `#9ca3af` → `var(--text-tertiary)`, `#e5e7eb`/`#f3f4f6` borders → `var(--surface-border)`/`var(--surface-bg)`, `#c62828` → `var(--error-fg)`, `#d1d5db` → `var(--toggle-track)`. The salmon `--brand-primary` references stay as-is.
+- [ ] **2.2 (M)** [src/components/AdminPortal.js](../../../src/components/AdminPortal.js) — same treatment; audit every colour literal in `addStyles()`.
+- [ ] **2.3 (S)** [src/components/LoadingSpinner.js](../../../src/components/LoadingSpinner.js) — sweep text/background/border literals.
+- [ ] **2.4 (S)** [src/components/StatusBadge.js](../../../src/components/StatusBadge.js) — sweep, preserving status colour semantics (success-green / warning-amber / error-red should remain readable on dark; may need per-token dark overrides if contrast fails — decide per-case).
+- [ ] **2.5 (S)** [src/components/UserAvatar.js](../../../src/components/UserAvatar.js) — audit; replace any hardcoded colours.
+- [ ] **2.6 (M)** [src/components/ToastContainer.js](../../../src/components/ToastContainer.js) — toast backgrounds for `success|error|warning|info|loading` must read well on dark. Prefer token references; add per-type dark overrides only where contrast genuinely fails.
+- [ ] **2.7 (S)** Visual diff pass: light mode on every page must still look identical. *(Validation gate.)*
+- [ ] **2.8 (S)** Manual dev-tools check: set `document.documentElement.dataset.theme = 'dark'` in DevTools console — every surface should flip coherently. No island of hardcoded light colour visible.
+
+**Validation**: Zero light-mode regression; forced-dark smoke test via DevTools shows fully themed surfaces.
+
+---
+
+## Group 3 — ThemeModule + Pre-Paint Script
+
+**Goal**: `ThemeModule` exists and is wired in `main.js`; inline pre-paint script prevents FOUC. Theme now resolves from `localStorage` (or `'system'` fallback) on every load — but is not yet connected to the user's Firestore preference. For signed-in users with a stored preference, the `system`/OS default applies until Group 4 lands.
+**Commit message**: `feat(theme): add ThemeModule and inline pre-paint script`
+**AC**: AC-3, AC-4, AC-5, AC-7, AC-8
+
+- [ ] **3.1 (L)** Create [src/modules/theme.js](../../../src/modules/theme.js) implementing `ThemeModule` per §XI.1:
+    - `THEMES = Object.freeze(['light','dark','system'])` whitelist.
+    - `STORAGE_KEY = 'salmoncow.theme'`.
+    - `init()` — reads localStorage (validated), applies, attaches `matchMedia` listener iff resolved == `'system'`.
+    - `applyPreference(theme)` — whitelist-validates; `console.warn` + no-op on invalid; sets `document.documentElement.dataset.theme`; writes localStorage; attaches/detaches `matchMedia` listener based on new value.
+    - `onProfileLoaded(profile)` — `applyPreference(profile?.preferences?.theme)`; guards against `null`/undefined.
+    - `onSignOut()` — no-op (localStorage already holds last-known; do **not** force `'system'`).
+    - `getResolvedTheme()` — returns `'light'|'dark'`; for tests.
+    - `destroy()` — idempotent `matchMedia().removeEventListener`.
+    - Internal helper `resolveSystem()` using `window.matchMedia('(prefers-color-scheme: dark)').matches`.
+    - Internal helper `validate(v)` returning whitelisted value or `null`.
+- [ ] **3.2 (M)** Add inline pre-paint `<script>` at the top of `<head>` in [src/index.html:7](../../../src/index.html) per §XI.4. Whitelist-on-read; try/catch around `localStorage`; sole sink is `document.documentElement.dataset.theme`. Keep it hand-written — **do not** import a module here (would defer past FOUC).
+- [ ] **3.3 (M)** In [src/main.js:55](../../../src/main.js) `init()`: import and instantiate `ThemeModule` before the UI module init; call `theme.init()` right after. Store on `this.theme` for later wiring.
+- [ ] **3.4 (S)** `npm run build` + `npm run dev:app`: signed-out cold load must pick up OS preference; reload must be FOUC-free on DevTools Slow-3G throttle. *(Validation gate.)*
+- [ ] **3.5 (S)** DevTools console: `app.theme.applyPreference('dark')` flips the UI; `'system'` reverts; `'garbage'` logs a warning and does nothing.
+
+**Validation**: OS preference respected on cold load; no FOUC on throttled reload; invalid inputs safely rejected.
+
+---
+
+## Group 4 — Profile Integration (Authoritative + Optimistic)
+
+**Goal**: Authenticated user's Firestore `preferences.theme` drives the applied theme on sign-in; user-initiated changes from the `<select>` apply instantly (optimistic) and persist via the existing `updatePreferences` path.
+**Commit message**: `feat(theme): wire ThemeModule to user profile state and optimistic updates`
+**AC**: AC-2, AC-6 (full coverage)
+
+- [ ] **4.1 (M)** In [src/main.js:174](../../../src/main.js) `initializeUserPortal()`, **after** `this.profileService` is constructed: register `this.profileService.onStateChange((profile) => this.theme.onProfileLoaded(profile))`. Store the unsubscribe returned by `onStateChange` on `this._themeProfileUnsub` for symmetry with other teardown.
+- [ ] **4.2 (M)** In [src/modules/user-portal.js:22](../../../src/modules/user-portal.js) `UserPortalModule` constructor: accept an optional second argument `{ theme }` DI. In `handlePreferenceChange(key, value)` at [user-portal.js:105](../../../src/modules/user-portal.js): if `key === 'theme'` and `this.theme`, call `this.theme.applyPreference(value)` **before** awaiting `updatePreferences`. On failure, the existing `loadProfile` fallback already refreshes from authoritative state — `onStateChange` will fire with the reverted value and `theme.onProfileLoaded` reapplies it. No extra revert logic needed.
+- [ ] **4.3 (S)** In [src/main.js:171](../../../src/main.js) `initializeUserPortal`: pass `{ theme: this.theme }` to the `UserPortalModule` constructor.
+- [ ] **4.4 (S)** `npm run dev` (emulator + app). Sign in; change dropdown to `dark` → UI flips within one animation frame. Refresh → dark persists. Inspect Firestore emulator UI → `users/{uid}.preferences.theme === 'dark'`. *(Validation gate.)*
+- [ ] **4.5 (S)** Sign out → theme **does not** flip (AC-5: stays on last-applied). Sign back in → Firestore value reapplies.
+
+**Validation**: Full round-trip: UI action → Firestore → next load reads correct theme; optimistic path is instant; revert path is handled by existing error plumbing.
+
+---
+
+## Group 5 — Unit Tests + Test Harness
+
+**Goal**: Add a plain-JS `test:unit` vitest lane and cover `ThemeModule` per §XI.6. Chain into root `test` script so CI runs it alongside rules + functions tests.
+**Commit message**: `test(theme): add ThemeModule unit tests and test:unit script`
+**AC**: AC-9
+
+- [ ] **5.1 (S)** Add `jsdom` to `devDependencies` if not already transitively available (run `npm ls jsdom` to check; add `"jsdom": "^25.0.0"` if missing).
+- [ ] **5.2 (S)** Add `vitest.config.js` at repo root (or extend if present) with `test.environment: 'jsdom'` scoped to `tests/unit/**`. Keep `tests/rules/**` on the default environment to not disturb the existing rules suite.
+- [ ] **5.3 (S)** `package.json`: add `"test:unit": "vitest run tests/unit"`. Update `"test"` to `"npm run test:rules && npm run test:functions && npm run test:unit"`.
+- [ ] **5.4 (L)** Create [tests/unit/modules/theme.test.js](../../../tests/unit/modules/theme.test.js) with the 10 cases enumerated in §XI.6:
+    - init: no localStorage → `'system'`-resolved.
+    - init: `localStorage='dark'` → `'dark'`, no matchMedia listener.
+    - init: `localStorage='system'` + mocked OS dark → `'dark'`, listener attached.
+    - init: `localStorage='garbage'` → `'system'`-resolved, bad value left in storage (will be overwritten on next valid `applyPreference`).
+    - `applyPreference('dark')` → dataset + localStorage updated, listener detached.
+    - `applyPreference('system')` → listener attached; mocked change flips dataset.
+    - `applyPreference('invalid')` → no-op, no throw, `console.warn` called.
+    - `destroy()` → `removeEventListener` invoked; subsequent mocked change events ignored.
+    - `onProfileLoaded({ preferences: { theme: 'light' } })` equivalent to `applyPreference('light')`.
+    - `onProfileLoaded(null)` → no-op.
+    Use `vi.fn()` for the `matchMedia` mock returning `{ matches, addEventListener, removeEventListener }`. AAA pattern; descriptive names.
+- [ ] **5.5 (S)** `npm run test:unit` → all green. *(Validation gate.)*
+- [ ] **5.6 (S)** `npm test` → all three lanes green (rules + functions + unit).
+
+**Validation**: All unit tests pass; chained test script green; no regression in existing lanes.
+
+---
+
+## Group 6 — Manual QA + PR
+
+**Goal**: Evidence-backed PR matching constitution §V.1 step 7 (Summary / Changes / Testing / Guidance References).
+**Commit message**: merged PR only — no new commit.
+**AC**: AC-1 through AC-12 (all)
+
+- [ ] **6.1 (M)** Execute the §XI.6 manual QA checklist in full — 10 checkboxes, two OS modes × multiple flows. Capture **both** light-mode and dark-mode screenshots for at least: `/`, `/profile`, `/admin` (if testable), the navigation dropdown, and a toast.
+- [ ] **6.2 (S)** Safari check: manual smoke test on macOS Safari (legacy `matchMedia.addListener` compat — our code uses the modern `addEventListener` which Safari has supported since 14; document Safari version tested).
+- [ ] **6.3 (S)** Write PR body: Summary, Changes (list the 6 commit groups), Testing (`npm test` output summary + manual QA checklist with links to screenshots), Guidance References (cite constitution §II.1 / §III.2 / §III.3 / §IV.2 / §VI.1, and the pattern files listed in §X of the spec).
+- [ ] **6.4 (S)** `gh pr create` targeting `main`. Link to the feature spec: `.specs/features/002-dark-mode-theme/spec.md`.
+- [ ] **6.5 (S)** After merge: `git mv .specs/features/002-dark-mode-theme/ .specs/archive/002-dark-mode-theme/` (per features/README.md lifecycle).
+
+**Validation**: PR merged green; feature archived.
+
+---
+
+## Follow-Up (Out of Scope — Do NOT Include in This PR)
+
+Flagged in §XI.2 of the spec:
+
+- **`UserProfileService.updatePreferences` map-merge bug** — current implementation writes `{ preferences: { [key]: value } }` to Firestore, which replaces the `preferences` map rather than merging. Risk: an older client or concurrent tab writing only `{ theme }` clobbers `{ emailNotifications }`. Not triggered by this feature alone (the only two preferences the service knows about are `theme` and `emailNotifications`, and both writes go through this same broken path, so the last-write-wins behaviour is internally consistent), **but** it's a latent correctness bug. Recommend a dedicated fix PR that merges against the current cached profile's preferences before writing, or switches to dotted-path `updateDoc(..., { 'preferences.theme': value })` — the latter is simpler. See [src/services/user-profile-service.js:121](../../../src/services/user-profile-service.js).
+
+---
+
+**Next step**: `/speckit-implement` to execute Groups 1 → 6 in order, committing at the end of each group only when the validation gate passes.

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "emulators": "mkdir -p .emulator-data && firebase emulators:start --only auth,firestore,functions --import=.emulator-data --export-on-exit=.emulator-data",
     "test:rules": "firebase emulators:exec --only firestore 'vitest run tests/rules'",
     "test:functions": "firebase emulators:exec --only auth,firestore,functions 'npm --prefix functions test'",
-    "test": "npm run test:rules && npm run test:functions",
+    "test:unit": "vitest run --config vitest.unit.config.ts",
+    "test": "npm run test:unit && npm run test:rules && npm run test:functions",
     "bootstrap:owner": "tsx scripts/bootstrap-owner.ts"
   },
   "devDependencies": {

--- a/src/assets/styles/navigation.css
+++ b/src/assets/styles/navigation.css
@@ -5,7 +5,12 @@
  * Responsive design with dropdown user profile menu
  */
 
-/* ===== CSS CUSTOM PROPERTIES ===== */
+/* ===== CSS CUSTOM PROPERTIES =====
+ * Brand tokens stay constant across themes. Surface tokens (--surface-*,
+ * --text-*, etc.) are defined in styles/main.css and overridden under
+ * [data-theme="dark"]; the dropdown mappings below consume those so the
+ * menu automatically picks up the dark palette.
+ */
 :root {
     /* Brand Colors - Extracted from logo.svg */
     --brand-primary: #D66E4F;        /* Salmon - main brand color */
@@ -13,18 +18,18 @@
     --brand-accent: #B7BCBC;         /* Gray - neutral accent */
     --brand-light: #F9FAF8;          /* Cream - light backgrounds */
 
-    /* Semantic Colors for Navigation */
+    /* Semantic Colors for Navigation — nav bar is branded (salmon) in both themes */
     --nav-bg: var(--brand-primary);
     --nav-text: #ffffff;
     --nav-hover-bg: rgba(255, 255, 255, 0.15);
     --nav-active-bg: rgba(255, 255, 255, 0.2);
 
-    /* Dropdown Colors */
-    --dropdown-bg: #ffffff;
-    --dropdown-text: #333333;
-    --dropdown-text-secondary: #6b7280;
-    --dropdown-border: #e5e7eb;
-    --dropdown-hover-bg: #f3f4f6;
+    /* Dropdown Colors — consume shared surface/text tokens so dark mode flips automatically */
+    --dropdown-bg: var(--surface-elevated);
+    --dropdown-text: var(--text-primary);
+    --dropdown-text-secondary: var(--text-secondary);
+    --dropdown-border: var(--surface-border);
+    --dropdown-hover-bg: var(--surface-bg);
 
     /* Layout Dimensions */
     --nav-height: 64px;
@@ -33,7 +38,7 @@
 
     /* Shadows */
     --nav-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-    --dropdown-shadow: 0 10px 25px rgba(0, 0, 0, 0.15);
+    --dropdown-shadow: var(--shadow-elevated);
 
     /* Transitions */
     --transition-speed: 0.2s;

--- a/src/components/AdminPortal.js
+++ b/src/components/AdminPortal.js
@@ -256,27 +256,32 @@ ${footer}`;
         const style = document.createElement('style');
         style.id = 'admin-portal-styles';
         style.textContent = `
-.admin-portal { padding: 2rem 1rem; max-width: 1100px; margin: 0 auto; }
+.admin-portal { padding: 2rem 1rem; max-width: 1100px; margin: 0 auto; color: var(--text-primary); }
 .admin-portal__header { margin-bottom: 1.5rem; }
 .admin-portal__header h1 { margin: 0 0 .25rem; font-size: 1.5rem; }
-.admin-portal__subtitle { margin: 0; color: var(--text-muted, #666); }
-.admin-portal__status { padding: 3rem 1rem; text-align: center; color: var(--text-muted, #666); }
-.admin-portal__status--error { color: var(--error, #c0392b); }
-.admin-portal__table-wrap { overflow-x: auto; border: 1px solid #ddd; border-radius: 8px; }
+.admin-portal__subtitle { margin: 0; color: var(--text-secondary); }
+.admin-portal__status { padding: 3rem 1rem; text-align: center; color: var(--text-secondary); }
+.admin-portal__status--error { color: var(--error-fg); }
+.admin-portal__table-wrap { overflow-x: auto; border: 1px solid var(--surface-border); border-radius: 8px; background: var(--surface-elevated); }
 .admin-portal__table { width: 100%; border-collapse: collapse; }
 .admin-portal__table th,
-.admin-portal__table td { padding: .75rem 1rem; text-align: left; border-bottom: 1px solid #eee; vertical-align: middle; }
-.admin-portal__table th { background: #f8f8f8; font-weight: 600; font-size: .875rem; }
+.admin-portal__table td { padding: .75rem 1rem; text-align: left; border-bottom: 1px solid var(--surface-border); vertical-align: middle; color: var(--text-primary); }
+.admin-portal__table th { background: var(--surface-muted); font-weight: 600; font-size: .875rem; color: var(--text-secondary); }
 .admin-portal__table tr:last-child td { border-bottom: none; }
 .admin-portal__user-cell { display: flex; align-items: center; gap: .75rem; }
 .admin-portal__display-name { font-weight: 500; }
-.admin-portal__role-badge { display: inline-block; padding: .25rem .5rem; border-radius: 4px; font-size: .875rem; background: #eee; color: #333; }
+.admin-portal__role-badge { display: inline-block; padding: .25rem .5rem; border-radius: 4px; font-size: .875rem; background: var(--surface-muted); color: var(--text-primary); }
 .admin-portal__role-badge--owner { background: #fef3c7; color: #92400e; }
 .admin-portal__role-badge--admin { background: #dbeafe; color: #1e40af; }
 .admin-portal__role-badge--user { background: #f3f4f6; color: #4b5563; }
-.admin-portal__role-select { padding: .35rem .5rem; border-radius: 4px; border: 1px solid #ccc; background: white; }
-.admin-portal__load-more { margin-top: 1rem; padding: .5rem 1rem; cursor: pointer; border: 1px solid #ccc; background: white; border-radius: 4px; }
+.admin-portal__role-select { padding: .35rem .5rem; border-radius: 4px; border: 1px solid var(--surface-border); background: var(--surface-elevated); color: var(--text-primary); }
+.admin-portal__load-more { margin-top: 1rem; padding: .5rem 1rem; cursor: pointer; border: 1px solid var(--surface-border); background: var(--surface-elevated); color: var(--text-primary); border-radius: 4px; }
 .admin-portal__load-more:disabled { opacity: .6; cursor: wait; }
+
+/* Role badges — dark palette overrides */
+[data-theme="dark"] .admin-portal__role-badge--owner { background: #422006; color: #fde68a; }
+[data-theme="dark"] .admin-portal__role-badge--admin { background: #172554; color: #bfdbfe; }
+[data-theme="dark"] .admin-portal__role-badge--user  { background: #1f2937; color: #d1d5db; }
 `;
         document.head.appendChild(style);
     }

--- a/src/components/LoadingSpinner.js
+++ b/src/components/LoadingSpinner.js
@@ -57,7 +57,8 @@ export class LoadingSpinner extends HTMLElement {
                         cy="25"
                         r="20"
                         fill="none"
-                        stroke="#e5e7eb"
+                        stroke="currentColor"
+                        stroke-opacity="0.15"
                         stroke-width="4"
                     />
                     <circle
@@ -66,7 +67,7 @@ export class LoadingSpinner extends HTMLElement {
                         cy="25"
                         r="20"
                         fill="none"
-                        stroke="#3b82f6"
+                        stroke="var(--brand-primary, #D66E4F)"
                         stroke-width="4"
                         stroke-linecap="round"
                         stroke-dasharray="31.4 31.4"
@@ -110,8 +111,12 @@ export class LoadingSpinner extends HTMLElement {
                 stroke-linecap: round;
             }
 
+            .loading-spinner-container {
+                color: var(--text-secondary);
+            }
+
             .loading-spinner-message {
-                color: #6b7280;
+                color: inherit;
                 font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
                 text-align: center;
             }
@@ -144,7 +149,8 @@ export class LoadingSpinner extends HTMLElement {
                 left: 0;
                 right: 0;
                 bottom: 0;
-                background: rgba(255, 255, 255, 0.95);
+                background: var(--surface-elevated);
+                opacity: 0.95;
                 display: flex;
                 align-items: center;
                 justify-content: center;

--- a/src/components/StatusBadge.js
+++ b/src/components/StatusBadge.js
@@ -169,7 +169,7 @@ export class StatusBadge extends HTMLElement {
                 opacity: 1;
             }
 
-            /* Type variants */
+            /* Type variants (light) */
             .status-badge-success {
                 background-color: #f0fdf4;
                 border-color: #86efac;
@@ -198,6 +198,37 @@ export class StatusBadge extends HTMLElement {
                 background-color: #f8fafc;
                 border-color: #cbd5e1;
                 color: #475569;
+            }
+
+            /* Type variants (dark) — inverted palette for readability on dark surfaces */
+            [data-theme="dark"] .status-badge-success {
+                background-color: #052e16;
+                border-color: #166534;
+                color: #bbf7d0;
+            }
+
+            [data-theme="dark"] .status-badge-error {
+                background-color: #450a0a;
+                border-color: #991b1b;
+                color: #fecaca;
+            }
+
+            [data-theme="dark"] .status-badge-warning {
+                background-color: #451a03;
+                border-color: #92400e;
+                color: #fde68a;
+            }
+
+            [data-theme="dark"] .status-badge-info {
+                background-color: #172554;
+                border-color: #1e40af;
+                color: #bfdbfe;
+            }
+
+            [data-theme="dark"] .status-badge-loading {
+                background-color: #1e293b;
+                border-color: #475569;
+                color: #cbd5e1;
             }
 
             /* Loading spinner animation */

--- a/src/components/UserAvatar.js
+++ b/src/components/UserAvatar.js
@@ -101,8 +101,8 @@ export class UserAvatar extends HTMLElement {
                 border-radius: 50%;
                 object-fit: cover;
                 display: inline-block;
-                background-color: #f3f4f6;
-                border: 1px solid #e5e7eb;
+                background-color: var(--surface-muted);
+                border: 1px solid var(--surface-border);
             }
 
             .user-avatar[data-size="small"] {

--- a/src/components/UserPortal.js
+++ b/src/components/UserPortal.js
@@ -239,9 +239,10 @@ export class UserPortal extends HTMLElement {
         style.id = 'user-portal-styles';
         style.textContent = `
             .user-portal {
-                background: white;
+                background: var(--surface-elevated);
+                color: var(--text-primary);
                 border-radius: 12px;
-                box-shadow: 0 4px 20px rgba(0, 0, 0, 0.08);
+                box-shadow: var(--shadow-card);
                 padding: 1.5rem;
                 max-width: 480px;
                 width: 100%;
@@ -258,7 +259,7 @@ export class UserPortal extends HTMLElement {
             /* Error State */
             .portal-error {
                 text-align: center;
-                color: #c62828;
+                color: var(--error-fg);
             }
 
             .portal-error-icon {
@@ -277,7 +278,7 @@ export class UserPortal extends HTMLElement {
                 align-items: center;
                 gap: 1rem;
                 padding-bottom: 1.25rem;
-                border-bottom: 1px solid #e5e7eb;
+                border-bottom: 1px solid var(--surface-border);
             }
 
             .portal-user-info {
@@ -288,7 +289,7 @@ export class UserPortal extends HTMLElement {
             .portal-name {
                 font-size: 1.25rem;
                 font-weight: 600;
-                color: #1f2937;
+                color: var(--text-primary);
                 margin: 0 0 0.25rem 0;
                 overflow: hidden;
                 text-overflow: ellipsis;
@@ -297,7 +298,7 @@ export class UserPortal extends HTMLElement {
 
             .portal-email {
                 font-size: 0.875rem;
-                color: #6b7280;
+                color: var(--text-secondary);
                 margin: 0 0 0.25rem 0;
                 overflow: hidden;
                 text-overflow: ellipsis;
@@ -306,7 +307,7 @@ export class UserPortal extends HTMLElement {
 
             .portal-member-since {
                 font-size: 0.75rem;
-                color: #9ca3af;
+                color: var(--text-tertiary);
                 margin: 0;
             }
 
@@ -318,7 +319,7 @@ export class UserPortal extends HTMLElement {
             .portal-section-title {
                 font-size: 0.875rem;
                 font-weight: 600;
-                color: #6b7280;
+                color: var(--text-secondary);
                 text-transform: uppercase;
                 letter-spacing: 0.05em;
                 margin: 0 0 1rem 0;
@@ -331,7 +332,7 @@ export class UserPortal extends HTMLElement {
                 justify-content: space-between;
                 gap: 1rem;
                 padding: 0.75rem 0;
-                border-bottom: 1px solid #f3f4f6;
+                border-bottom: 1px solid var(--surface-muted);
             }
 
             .portal-preference:last-child {
@@ -347,37 +348,37 @@ export class UserPortal extends HTMLElement {
                 display: block;
                 font-size: 0.9375rem;
                 font-weight: 500;
-                color: #1f2937;
+                color: var(--text-primary);
             }
 
             .preference-description {
                 display: block;
                 font-size: 0.8125rem;
-                color: #9ca3af;
+                color: var(--text-tertiary);
                 margin-top: 0.125rem;
             }
 
             /* Select */
             .portal-select {
                 padding: 0.5rem 2rem 0.5rem 0.75rem;
-                border: 1px solid #d1d5db;
+                border: 1px solid var(--surface-border);
                 border-radius: 6px;
                 font-size: 0.875rem;
-                color: #374151;
-                background: white url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%236b7280' stroke-width='2'%3E%3Cpath d='M6 9l6 6 6-6'/%3E%3C/svg%3E") no-repeat right 0.5rem center;
+                color: var(--text-primary);
+                background: var(--surface-elevated) url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%236b7280' stroke-width='2'%3E%3Cpath d='M6 9l6 6 6-6'/%3E%3C/svg%3E") no-repeat right 0.5rem center;
                 appearance: none;
                 cursor: pointer;
                 min-width: 120px;
             }
 
             .portal-select:hover {
-                border-color: #9ca3af;
+                border-color: var(--text-tertiary);
             }
 
             .portal-select:focus {
                 outline: none;
                 border-color: var(--brand-primary, #D66E4F);
-                box-shadow: 0 0 0 3px rgba(214, 110, 79, 0.1);
+                box-shadow: 0 0 0 3px var(--focus-ring);
             }
 
             /* Toggle Switch */
@@ -402,7 +403,7 @@ export class UserPortal extends HTMLElement {
                 left: 0;
                 right: 0;
                 bottom: 0;
-                background-color: #d1d5db;
+                background-color: var(--toggle-track);
                 transition: 0.2s;
                 border-radius: 24px;
             }
@@ -414,7 +415,7 @@ export class UserPortal extends HTMLElement {
                 width: 18px;
                 left: 3px;
                 bottom: 3px;
-                background-color: white;
+                background-color: #ffffff;
                 transition: 0.2s;
                 border-radius: 50%;
                 box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
@@ -429,7 +430,7 @@ export class UserPortal extends HTMLElement {
             }
 
             .portal-toggle input:focus + .portal-toggle-slider {
-                box-shadow: 0 0 0 3px rgba(214, 110, 79, 0.2);
+                box-shadow: 0 0 0 3px var(--focus-ring);
             }
 
             /* Responsive */

--- a/src/index.html
+++ b/src/index.html
@@ -4,6 +4,20 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Salmoncow</title>
+    <!-- Pre-paint theme: set <html data-theme> before stylesheets to prevent FOUC.
+         Kept inline + synchronous and hand-written; do NOT import a module here. -->
+    <script>
+        (function () {
+            try {
+                var v = localStorage.getItem('salmoncow.theme');
+                if (v !== 'light' && v !== 'dark' && v !== 'system') v = 'system';
+                var resolved = v === 'system'
+                    ? (matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light')
+                    : v;
+                document.documentElement.dataset.theme = resolved;
+            } catch (_) { /* storage disabled or pre-paint query failed — accept default */ }
+        })();
+    </script>
 </head>
 <body>
     <!-- Navigation Bar -->

--- a/src/main.js
+++ b/src/main.js
@@ -182,7 +182,13 @@ class App {
         const repositoryFactory = createRepositoryFactory({ firebaseApp: this.firebaseApp });
         this._userRepository = repositoryFactory.getUserProfileRepository();
         this.profileService = new UserProfileService(this._userRepository);
-        this.userPortal = new UserPortalModule(this.profileService);
+        // Authoritative theme apply: whenever the cached profile changes
+        // (sign-in, successful preference update, or post-revert reload),
+        // re-apply the stored theme preference to the DOM.
+        this._themeProfileUnsub = this.profileService.onStateChange((profile) =>
+            this.theme?.onProfileLoaded(profile),
+        );
+        this.userPortal = new UserPortalModule(this.profileService, { theme: this.theme });
         this.userPortal.init('userPortalContainer');
     }
 

--- a/src/main.js
+++ b/src/main.js
@@ -21,6 +21,7 @@ import { NavigationModule } from './modules/navigation.js';
 import { UserPortalModule } from './modules/user-portal.js';
 import { RouterModule } from './modules/router.js';
 import { AuthHintModule } from './modules/auth-hint.js';
+import { ThemeModule } from './modules/theme.js';
 import { createRepositoryFactory } from './factories/repository-factory.js';
 import { UserProfileService } from './services/user-profile-service.js';
 import { AdminUserService } from './services/admin-user-service.js';
@@ -50,11 +51,20 @@ class App {
         this.adminUserService = null;
         this.router = null;
         this.toastContainer = null;
+        this.theme = null;
     }
 
     async init() {
         try {
-            // Initialize UI and navigation modules first
+            // Theme first: the inline pre-paint script in index.html already set
+            // <html data-theme> from localStorage; ThemeModule.init() re-applies
+            // using the same cache and wires the system-preference watcher if the
+            // preference is 'system'. Firestore value takes over once the profile
+            // loads (see setupAuthStateListener → profileService.onStateChange).
+            this.theme = new ThemeModule();
+            this.theme.init();
+
+            // Initialize UI and navigation modules
             this.ui = new UIModule();
             this.navigation = new NavigationModule();
             this.ui.init();

--- a/src/modules/theme.js
+++ b/src/modules/theme.js
@@ -1,0 +1,156 @@
+/**
+ * ThemeModule
+ *
+ * Applies the user's colour-scheme preference to <html data-theme>.
+ * Three inputs, ordered by authority:
+ *   1. Firestore preferences.theme (when signed-in) — authoritative.
+ *   2. localStorage 'salmoncow.theme' — first-paint cache + signed-out default.
+ *   3. window.matchMedia('(prefers-color-scheme: dark)') — resolves 'system'.
+ *
+ * The inline pre-paint <script> in src/index.html handles the FOUC-critical
+ * first-paint step using the same localStorage key; this module takes over
+ * once the app bundle loads, then stays in sync via optimistic apply and
+ * profile-state callbacks (see main.js + modules/user-portal.js).
+ *
+ * Pure DOM + window APIs; no Firebase imports; no service dependencies.
+ *
+ * Feature spec: .specs/features/002-dark-mode-theme/spec.md §XI.1
+ */
+
+const THEMES = Object.freeze(['light', 'dark', 'system']);
+const STORAGE_KEY = 'salmoncow.theme';
+const SYSTEM_QUERY = '(prefers-color-scheme: dark)';
+
+function validate(v) {
+    return THEMES.includes(v) ? v : null;
+}
+
+function readStored() {
+    try {
+        return validate(window.localStorage.getItem(STORAGE_KEY)) ?? 'system';
+    } catch {
+        return 'system';
+    }
+}
+
+function writeStored(v) {
+    try {
+        window.localStorage.setItem(STORAGE_KEY, v);
+    } catch {
+        /* private-mode / disabled storage: ignore */
+    }
+}
+
+export class ThemeModule {
+    constructor() {
+        this._preference = 'system';
+        this._mediaQuery = null;
+        this._mediaListener = null;
+    }
+
+    /**
+     * Read the cached preference, apply it, and wire the system-preference
+     * watcher if the resolved preference is 'system'. Idempotent.
+     */
+    init() {
+        this.applyPreference(readStored());
+    }
+
+    /**
+     * Apply an explicit preference. Whitelisted; invalid values are a no-op
+     * with a console warning. Updates DOM attribute, localStorage, and the
+     * matchMedia subscription.
+     *
+     * @param {'light'|'dark'|'system'} theme
+     */
+    applyPreference(theme) {
+        const valid = validate(theme);
+        if (!valid) {
+            console.warn(`ThemeModule: ignoring invalid theme "${theme}"`);
+            return;
+        }
+        this._preference = valid;
+        writeStored(valid);
+        this._renderResolved();
+        if (valid === 'system') {
+            this._attachSystemWatcher();
+        } else {
+            this._detachSystemWatcher();
+        }
+    }
+
+    /**
+     * Called from the profile-state hook. Accepts the full profile object or
+     * null (signed-out). Ignores profiles missing a preference.
+     *
+     * @param {{ preferences?: { theme?: string } } | null} profile
+     */
+    onProfileLoaded(profile) {
+        const pref = profile?.preferences?.theme;
+        if (!pref) return;
+        this.applyPreference(pref);
+    }
+
+    /**
+     * Called on sign-out. Intentional no-op: the localStorage cache still
+     * holds the last-known preference, and leaving it applied avoids a
+     * jarring flash back to 'system' during the sign-out animation.
+     * Spec AC-5.
+     */
+    onSignOut() {
+        /* no-op — see docstring */
+    }
+
+    /**
+     * @returns {'light'|'dark'} The currently-applied resolved theme.
+     *                           Exposed for tests and diagnostics.
+     */
+    getResolvedTheme() {
+        return this._resolve(this._preference);
+    }
+
+    /**
+     * Tear down the matchMedia listener. Idempotent.
+     */
+    destroy() {
+        this._detachSystemWatcher();
+    }
+
+    /* ---------- internals ---------- */
+
+    _resolve(preference) {
+        if (preference === 'light' || preference === 'dark') return preference;
+        try {
+            return window.matchMedia(SYSTEM_QUERY).matches ? 'dark' : 'light';
+        } catch {
+            return 'light';
+        }
+    }
+
+    _renderResolved() {
+        const resolved = this._resolve(this._preference);
+        try {
+            document.documentElement.dataset.theme = resolved;
+        } catch {
+            /* SSR / test environment without document: ignore */
+        }
+    }
+
+    _attachSystemWatcher() {
+        if (this._mediaQuery) return;
+        try {
+            this._mediaQuery = window.matchMedia(SYSTEM_QUERY);
+        } catch {
+            return;
+        }
+        this._mediaListener = () => this._renderResolved();
+        this._mediaQuery.addEventListener('change', this._mediaListener);
+    }
+
+    _detachSystemWatcher() {
+        if (!this._mediaQuery || !this._mediaListener) return;
+        this._mediaQuery.removeEventListener('change', this._mediaListener);
+        this._mediaQuery = null;
+        this._mediaListener = null;
+    }
+}

--- a/src/modules/user-portal.js
+++ b/src/modules/user-portal.js
@@ -18,12 +18,17 @@ export class UserPortalModule {
     /**
      * Create UserPortalModule
      * @param {import('../services/user-profile-service.js').UserProfileService} profileService
+     * @param {{ theme?: import('./theme.js').ThemeModule }} [options] Optional DI:
+     *   - theme: apply theme changes optimistically for instant UI response.
+     *     The authoritative apply happens via profileService.onStateChange()
+     *     wired in main.js, so this module only needs to fire-and-forget.
      */
-    constructor(profileService) {
+    constructor(profileService, { theme = null } = {}) {
         if (!profileService) {
             throw new Error('ProfileService is required');
         }
         this.profileService = profileService;
+        this.theme = theme;
         this.container = null;
         this.portal = null;
         this.currentUser = null;
@@ -104,6 +109,14 @@ export class UserPortalModule {
      */
     async handlePreferenceChange(key, value) {
         if (!this.currentUser) return;
+
+        // Optimistic apply for instant UI response. On failure, the profile
+        // reload below re-fires ThemeModule.onProfileLoaded via the
+        // profileService.onStateChange subscription registered in main.js,
+        // so the reverted value automatically re-applies.
+        if (key === 'theme' && this.theme) {
+            this.theme.applyPreference(value);
+        }
 
         const preferences = { [key]: value };
         const result = await this.profileService.updatePreferences(

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -4,9 +4,55 @@
     box-sizing: border-box;
 }
 
+/* ===== THEME TOKENS =====
+ * Semantic surface/text tokens shared across all light-DOM components.
+ * Brand tokens (--brand-*) live in navigation.css and stay constant in both themes.
+ * Dark overrides live in the [data-theme="dark"] block below.
+ */
+:root {
+    --surface-bg:        #f3f4f6;
+    --surface-elevated:  #ffffff;
+    --surface-border:    #e5e7eb;
+    --surface-muted:     #f3f4f6;
+
+    --text-primary:      #1f2937;
+    --text-secondary:    #6b7280;
+    --text-tertiary:     #9ca3af;
+    --text-inverse:      #ffffff;
+
+    --focus-ring:        rgba(214, 110, 79, 0.2);
+    --shadow-card:       0 4px 20px rgba(0, 0, 0, 0.08);
+    --shadow-elevated:   0 10px 25px rgba(0, 0, 0, 0.15);
+
+    --error-fg:          #c62828;
+    --toggle-track:      #d1d5db;
+}
+
+[data-theme="dark"] {
+    color-scheme: light dark;
+
+    --surface-bg:        #0b1220;
+    --surface-elevated:  #111827;
+    --surface-border:    #1f2937;
+    --surface-muted:     #1f2937;
+
+    --text-primary:      #f3f4f6;
+    --text-secondary:    #9ca3af;
+    --text-tertiary:     #6b7280;
+    /* --text-inverse stays white — it's the on-brand-primary text */
+
+    --focus-ring:        rgba(214, 110, 79, 0.35);
+    --shadow-card:       0 4px 20px rgba(0, 0, 0, 0.45);
+    --shadow-elevated:   0 10px 25px rgba(0, 0, 0, 0.6);
+
+    --error-fg:          #f87171;
+    --toggle-track:      #374151;
+}
+
 body {
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', sans-serif;
-    background: #f3f4f6;
+    background: var(--surface-bg);
+    color: var(--text-primary);
     min-height: 100vh;
 }
 

--- a/tests/unit/modules/theme.test.js
+++ b/tests/unit/modules/theme.test.js
@@ -1,0 +1,235 @@
+/**
+ * Unit tests for ThemeModule.
+ *
+ * Run in a plain-node environment: window, document, localStorage, and
+ * matchMedia are stubbed via vi.stubGlobal — no jsdom dependency needed.
+ *
+ * Feature spec: .specs/features/002-dark-mode-theme/spec.md §XI.6
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ThemeModule } from '../../../src/modules/theme.js';
+
+/* ---------- stub helpers ---------- */
+
+function makeMatchMedia(initialMatches = false) {
+    const listeners = new Set();
+    const mq = {
+        matches: initialMatches,
+        addEventListener: vi.fn((event, fn) => {
+            if (event === 'change') listeners.add(fn);
+        }),
+        removeEventListener: vi.fn((event, fn) => {
+            if (event === 'change') listeners.delete(fn);
+        }),
+        /** Test helper: simulate an OS preference change. */
+        _fire(nextMatches) {
+            mq.matches = nextMatches;
+            for (const fn of listeners) fn({ matches: nextMatches });
+        },
+        _listenerCount: () => listeners.size,
+    };
+    const matchMedia = vi.fn(() => mq);
+    return { mq, matchMedia };
+}
+
+function makeLocalStorage(initial = {}) {
+    const store = { ...initial };
+    return {
+        getItem: vi.fn((k) => (k in store ? store[k] : null)),
+        setItem: vi.fn((k, v) => {
+            store[k] = String(v);
+        }),
+        removeItem: vi.fn((k) => {
+            delete store[k];
+        }),
+        clear: vi.fn(() => {
+            for (const k of Object.keys(store)) delete store[k];
+        }),
+        _store: store,
+    };
+}
+
+function makeDocument() {
+    const dataset = {};
+    return {
+        documentElement: { dataset },
+    };
+}
+
+function stubEnv({ stored = undefined, osDark = false } = {}) {
+    const localStorage = makeLocalStorage(
+        stored === undefined ? {} : { 'salmoncow.theme': stored },
+    );
+    const { mq, matchMedia } = makeMatchMedia(osDark);
+    const document = makeDocument();
+    vi.stubGlobal('window', { localStorage, matchMedia });
+    vi.stubGlobal('localStorage', localStorage);
+    vi.stubGlobal('matchMedia', matchMedia);
+    vi.stubGlobal('document', document);
+    return { localStorage, matchMedia, mq, document };
+}
+
+/* ---------- tests ---------- */
+
+describe('ThemeModule', () => {
+    let warnSpy;
+
+    beforeEach(() => {
+        warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        warnSpy.mockRestore();
+    });
+
+    it('init() with no localStorage resolves "system" against the OS preference (light)', () => {
+        const { document, mq } = stubEnv({ stored: undefined, osDark: false });
+        const theme = new ThemeModule();
+
+        theme.init();
+
+        expect(document.documentElement.dataset.theme).toBe('light');
+        expect(mq._listenerCount()).toBe(1); // system mode → watcher attached
+    });
+
+    it('init() with localStorage="dark" applies dark and does NOT attach the matchMedia listener', () => {
+        const { document, mq } = stubEnv({ stored: 'dark', osDark: false });
+        const theme = new ThemeModule();
+
+        theme.init();
+
+        expect(document.documentElement.dataset.theme).toBe('dark');
+        expect(mq._listenerCount()).toBe(0);
+    });
+
+    it('init() with localStorage="system" + OS-dark applies dark and attaches the listener', () => {
+        const { document, mq } = stubEnv({ stored: 'system', osDark: true });
+        const theme = new ThemeModule();
+
+        theme.init();
+
+        expect(document.documentElement.dataset.theme).toBe('dark');
+        expect(mq._listenerCount()).toBe(1);
+    });
+
+    it('init() with a garbage localStorage value falls back to system-resolved', () => {
+        const { document } = stubEnv({ stored: 'purple', osDark: false });
+        const theme = new ThemeModule();
+
+        theme.init();
+
+        expect(document.documentElement.dataset.theme).toBe('light');
+    });
+
+    it('applyPreference("dark") sets dataset + localStorage and detaches any system listener', () => {
+        const { document, localStorage, mq } = stubEnv({ stored: 'system', osDark: false });
+        const theme = new ThemeModule();
+        theme.init();
+        expect(mq._listenerCount()).toBe(1);
+
+        theme.applyPreference('dark');
+
+        expect(document.documentElement.dataset.theme).toBe('dark');
+        expect(localStorage.setItem).toHaveBeenCalledWith('salmoncow.theme', 'dark');
+        expect(mq._listenerCount()).toBe(0);
+    });
+
+    it('applyPreference("system") attaches the listener; OS change flips the resolved theme', () => {
+        const { document, mq } = stubEnv({ stored: 'dark', osDark: false });
+        const theme = new ThemeModule();
+        theme.init();
+        expect(mq._listenerCount()).toBe(0);
+
+        theme.applyPreference('system');
+        expect(mq._listenerCount()).toBe(1);
+        expect(document.documentElement.dataset.theme).toBe('light'); // OS is light
+
+        mq._fire(true); // OS switches to dark
+        expect(document.documentElement.dataset.theme).toBe('dark');
+    });
+
+    it('applyPreference() with an invalid value is a no-op and warns', () => {
+        const { document, localStorage } = stubEnv({ stored: 'light', osDark: false });
+        const theme = new ThemeModule();
+        theme.init();
+        localStorage.setItem.mockClear();
+        document.documentElement.dataset.theme = 'light';
+
+        theme.applyPreference('neon');
+
+        expect(document.documentElement.dataset.theme).toBe('light');
+        expect(localStorage.setItem).not.toHaveBeenCalled();
+        expect(warnSpy).toHaveBeenCalledOnce();
+    });
+
+    it('destroy() removes the matchMedia listener; subsequent OS changes are ignored', () => {
+        const { document, mq } = stubEnv({ stored: 'system', osDark: false });
+        const theme = new ThemeModule();
+        theme.init();
+        expect(mq._listenerCount()).toBe(1);
+
+        theme.destroy();
+        expect(mq._listenerCount()).toBe(0);
+
+        const before = document.documentElement.dataset.theme;
+        mq._fire(true);
+        expect(document.documentElement.dataset.theme).toBe(before);
+    });
+
+    it('destroy() is idempotent', () => {
+        const { mq } = stubEnv({ stored: 'system', osDark: false });
+        const theme = new ThemeModule();
+        theme.init();
+
+        theme.destroy();
+        theme.destroy();
+
+        expect(mq._listenerCount()).toBe(0);
+    });
+
+    it('onProfileLoaded({ preferences: { theme: "light" } }) is equivalent to applyPreference("light")', () => {
+        const { document, localStorage } = stubEnv({ stored: 'system', osDark: true });
+        const theme = new ThemeModule();
+        theme.init();
+        expect(document.documentElement.dataset.theme).toBe('dark');
+
+        theme.onProfileLoaded({ preferences: { theme: 'light' } });
+
+        expect(document.documentElement.dataset.theme).toBe('light');
+        expect(localStorage.setItem).toHaveBeenLastCalledWith('salmoncow.theme', 'light');
+    });
+
+    it('onProfileLoaded(null) is a no-op (signed-out guard)', () => {
+        const { document } = stubEnv({ stored: 'dark', osDark: false });
+        const theme = new ThemeModule();
+        theme.init();
+        const before = document.documentElement.dataset.theme;
+
+        theme.onProfileLoaded(null);
+
+        expect(document.documentElement.dataset.theme).toBe(before);
+    });
+
+    it('onProfileLoaded({ preferences: {} }) with missing theme is a no-op', () => {
+        const { document } = stubEnv({ stored: 'dark', osDark: false });
+        const theme = new ThemeModule();
+        theme.init();
+        const before = document.documentElement.dataset.theme;
+
+        theme.onProfileLoaded({ preferences: {} });
+
+        expect(document.documentElement.dataset.theme).toBe(before);
+    });
+
+    it('getResolvedTheme() returns the currently-applied concrete theme', () => {
+        stubEnv({ stored: 'system', osDark: true });
+        const theme = new ThemeModule();
+        theme.init();
+
+        expect(theme.getResolvedTheme()).toBe('dark');
+
+        theme.applyPreference('light');
+        expect(theme.getResolvedTheme()).toBe('light');
+    });
+});

--- a/vitest.unit.config.ts
+++ b/vitest.unit.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vitest/config';
+
+// Unit-test config for pure-JS modules (no emulator, no jsdom).
+// Kept separate from vitest.config.ts (rules suite) so the two lanes
+// stay independent and rules tests don't pick up unit files.
+export default defineConfig({
+    test: {
+        include: ['tests/unit/**/*.test.js'],
+        environment: 'node',
+        testTimeout: 5_000,
+    },
+});


### PR DESCRIPTION
## Summary

- Adds runtime dark/light/system theme switching across the SalmonCow web app with user preference persisted in the Firestore `users/{uid}.preferences.theme` field.
- Data model (`UserPreferences.theme: 'light' | 'dark' | 'system'`) and write path (`UserProfileService.updatePreferences()`) already existed from the RBAC feature; this PR builds **everything downstream** — a `ThemeModule` runtime, an inline pre-paint script to eliminate FOUC, and a CSS-token refactor across surfaces and components.
- Zero new Firestore reads, ~1 write per user-initiated change. Zero new npm deps. Stays in UI Phase 1 (Vanilla Web Components + CSS custom properties) per constitution §II.1.

## Feature spec

Full spec + technical implementation plan + task breakdown: [.specs/features/002-dark-mode-theme/](.specs/features/002-dark-mode-theme/) — 6 commit-grouped tasks, each landed in a single commit.

## Changes (6 commits, land-in-stages order)

| # | Commit | Scope |
|---|---|---|
| 1 | `docs(specs): add feature spec for dark-mode theme (002)` | Spec + tasks |
| 2 | `feat(theme): add :root semantic tokens and dark override layer` | `main.css` tokens + `[data-theme="dark"]` block; `navigation.css` dropdown tokens remapped onto shared surface tokens. **Zero visual change.** |
| 3 | `refactor(components): use surface tokens in component styles for theme support` | UserAvatar, LoadingSpinner, StatusBadge, AdminPortal, UserPortal migrated; StatusBadge + role-badge dark overrides added. **Zero visual change.** |
| 4 | `feat(theme): add ThemeModule and inline pre-paint script` | New `src/modules/theme.js` + inline `<script>` in `src/index.html`. **First commit that activates dark mode.** |
| 5 | `feat(theme): wire ThemeModule to user profile state and optimistic updates` | `onStateChange` subscription (authoritative) + optimistic apply from `UserPortalModule`. |
| 6 | `test(theme): add ThemeModule unit tests and test:unit lane` | 13 new unit tests; new `vitest.unit.config.ts`; `test:unit` script chained into root `test`. |

**Ordering rationale**: commits 2–3 are invisible refactors (nothing sets `<html data-theme>` yet). Any revert up through commit 3 is zero-risk to production light-mode users. Commit 4 is the first commit where dark mode can actually appear.

## Architecture

- **`ThemeModule`** (`src/modules/theme.js`, ~150 LOC) — pure DOM + `window` APIs. No Firebase imports, no service coupling. Receives theme values as plain strings. Idempotent `init`/`applyPreference`/`destroy`. `matchMedia('(prefers-color-scheme: dark)')` listener attached **only** while preference is `'system'`; detached whenever preference is explicit or on `destroy()`.
- **Inline pre-paint script** (`src/index.html`) — hand-written synchronous `<script>` at the top of `<head>`. Whitelist-on-read from `localStorage['salmoncow.theme']`, resolves `'system'` via `matchMedia`, sets `<html data-theme>` **before stylesheets evaluate** to eliminate FOUC. ~300B in HTML; try/catch around `localStorage` for private-mode Safari.
- **CSS token layer** — `:root` semantic tokens (`--surface-bg`, `--text-primary`, `--shadow-card`, `--error-fg`, `--focus-ring`, `--toggle-track`) with `[data-theme="dark"]` overrides. Brand colours (`--brand-primary` salmon) stay constant in both themes. StatusBadge and AdminPortal role badges keep light-mode semantic palettes plus paired dark-theme overrides for readability.
- **Apply paths** — user-initiated changes fire **optimistically** from `UserPortalModule.handlePreferenceChange()` for instant UI response, and **authoritatively** via `profileService.onStateChange()` once Firestore confirms. Double-apply is a no-op because `ThemeModule` is idempotent. Revert path reuses existing `loadProfile()` fallback — no bespoke revert logic.

## Security

- **Whitelist validation on every boundary** (§III.2): pre-paint script, `ThemeModule.applyPreference()`, and `localStorage` reads all validate against `['light','dark','system']` and fall back to `'system'` on anything else.
- **No XSS surface**: the only sinks are `document.documentElement.dataset.theme` (attribute, whitelisted) and `localStorage.setItem` (whitelisted). No `innerHTML`, no string concat into HTML.
- **No Firestore rules change**: `preferences.theme` already flows through the existing owner-only write path; this PR does not touch `firestore.rules`.

## Cost / quota (§VI.1)

- **0 new Firestore reads** — theme is extracted from the same `getOrCreateProfile` fetch that already loads on sign-in.
- **~1 write per user-initiated theme change** via the existing `updatePreferences` path. At 1,000 DAU × 1 change/month ≈ 0.16% of Blaze free write quota.
- **0 new listeners** against Firestore. `matchMedia` listener is DOM-only and torn down in `destroy()`.

## Bundle impact

| Artifact | Before | After | Δ |
|---|---|---|---|
| `dist/index.html` | 5.09 kB | 5.82 kB | +730 B (inline pre-paint script) |
| `dist/assets/styles/*.css` | 6.36 kB | 6.36 kB | +0 |
| `dist/assets/js/index-*.js` | 58.96 kB | 62.82 kB | +3.9 kB (ThemeModule + dark-variant CSS strings in component `addStyles()`) |

Total gzip page-weight delta: ~1 kB gzip. Well inside any reasonable perf budget.

## Test plan

- [x] `npm run test:unit` → **13/13 pass** (new ThemeModule tests: init variants, applyPreference, matchMedia watcher lifecycle, onProfileLoaded, destroy idempotency, getResolvedTheme, invalid-value rejection)
- [x] `npm test` → **72/72 pass** (13 unit + 41 rules + 18 functions)
- [x] `npm run build` → clean on every intermediate commit
- [x] **Manual QA confirmed in dev environment** — dark mode works end-to-end (user-verified before merge request)
- [ ] Post-merge: verify live site on Safari + Chrome after deploy-frontend workflow runs

## Constitutional compliance

- **§II.1** — Stays in UI Phase 1 (Vanilla Web Components, CSS custom properties). No framework introduced. Module count: 8 → 9, still under the 10-module Phase-2 testing trigger.
- **§II.3** — `ThemeModule` is single-responsibility; dependency direction respected (module depends only on `window`/DOM; called from `App` presentation layer; does not import services or Firebase).
- **§III.1** — 13 unit tests with AAA pattern + descriptive scenario names, proportional to criticality (theme is not a critical path).
- **§III.2** — Boundary whitelist validation at all three entry points (pre-paint, init, applyPreference).
- **§III.3** — Inline pre-paint script eliminates FOUC; FCP budget unaffected.
- **§IV.2** — No unbounded reads, no uncleaned listeners (matchMedia torn down in `destroy()`), no new `onSnapshot`, no god modules.
- **§VI.1** — Zero new Firestore reads; ~1 write/user/change; Blaze free quota untouched.

## Known out-of-scope (flagged in spec §XI.9, not addressed here)

- **`UserProfileService.updatePreferences` map-merge concern** — current implementation writes `{ preferences: { [key]: value } }` which Firestore treats as a map replace rather than merge. Not triggered by this PR alone (both known preferences — `theme`, `emailNotifications` — go through the same path), but a latent correctness bug. Recommended follow-up: switch to dotted-path `updateDoc(..., { 'preferences.theme': value })` in a dedicated PR.

## Guidance references

- `.specs/constitution.md` §II.1, §II.3, §III.1, §III.2, §III.3, §IV.2, §VI.1
- `.specs/features/002-dark-mode-theme/spec.md` §I–§XI (spec + technical implementation plan)
- `.prompts/core/architecture/modular-architecture-principles.md` — single-responsibility module
- `.prompts/core/architecture/code-structure.md` — modules/ layer placement
- `.prompts/core/security/security-principles.md` — input validation at boundaries
- `.prompts/core/testing/testing-principles.md` — AAA + descriptive scenario names
- `.prompts/core/development/asset-reusability.md` — design tokens over hardcoded colours
- `.prompts/platforms/firebase/firebase-best-practices.md` — one-shot reads over listeners for rarely-changing data
- `.prompts/platforms/firebase/firebase-finops.md` — 0-read designs

🤖 Generated with [Claude Code](https://claude.com/claude-code)