### PR TITLE
refactor(rbac): unify setUserRole into single TX, port §VI from citl

### DIFF
--- a/.specs/archive/001-multi-user-rbac/spec.md
+++ b/.specs/archive/001-multi-user-rbac/spec.md
@@ -125,7 +125,113 @@ Introduce a three-role role-based access control (RBAC) system for Salmoncow. Al
 
 ---
 
-## VI. Security Requirements
+## VI. Design Decisions
+
+This section captures non-obvious implementation choices and the
+reasoning behind them. Self-contained so it can be ported to sibling
+projects (e.g. citl) that share the same architecture.
+
+### VI.1 `setUserRole` write ordering — claim-first
+
+**Problem.** A role change is a *cross-system* write that touches:
+
+1. **Firebase Auth** — the custom claim (`request.auth.token.role`) is
+   the rules-engine source of truth.
+2. **Firestore** — three records:
+   - `users/{uid}` mirror (admin-UI source of truth + `roleChangedAt`
+     watermark for forcing target token refresh)
+   - `audit/{auto}` append-only forensics record
+   - `rateLimits/setUserRole/actors/{actorUid}` abuse counter
+
+There is no native atomic transaction across Firebase Auth and
+Firestore. The Auth API call and the Firestore commit happen
+sequentially. If the second of the two fails, the system ends up in a
+partially-applied state. The **ordering** of the two operations
+determines what that partial state looks like — and crucially,
+whether it fails *open* or *closed* for the security boundary.
+
+**Failure-mode analysis.**
+
+| Ordering | If second op fails | Effect on a *demotion* | Effect on a *promotion* |
+|----------|-------------------|------------------------|--------------------------|
+| TX-first, then claim | Claim stale | User keeps old privileges (**fail-open** for revocation) | User can't use new role yet (fail-closed) |
+| **Claim-first, then TX** | Mirror + audit incomplete | User loses access immediately (**fail-closed** for revocation) | User has new role with stale audit row (recoverable) |
+
+**Decision: claim-first.** The auth custom claim is the rules-engine
+source of truth — Firestore rules read `request.auth.token.role`, not
+the mirror. Therefore:
+
+1. **Revocations take effect immediately even if the TX fails.** This
+   is fail-closed for the security-critical path (an admin or owner
+   losing access is a higher-stakes event than a new admin being
+   granted access).
+2. **Mirror + audit drift is recoverable.** The actor's identity and
+   timestamp are still captured by Cloud Audit Logs. The next
+   `setUserRole` call for the same target reads the now-stale mirror,
+   observes the divergence, and re-writes both atomically.
+3. **No additional infrastructure required for production-readiness.**
+   TX-first ordering would need a separate scheduled reconciliation
+   job (claim-vs-mirror drift scanner) to be production-safe; the
+   security gap on revocation is otherwise unmitigated. Claim-first is
+   production-safe as a code-only solution.
+
+**Implementation pattern.** The Auth API call lives *inside* the
+Firestore transaction function but *before* the queued Firestore
+writes:
+
+```ts
+await db.runTransaction(async (tx) => {
+  const userSnap = await tx.get(userRef);
+  if (!userSnap.exists) throw new HttpsError('not-found', ...);
+  const fromRole = userSnap.data().role;
+
+  await assertNotLastOwner(tx, db, fromRole, newRole);   // TX-internal read
+  await checkAndBumpInTransaction(tx, db, actorUid);     // queues counter write
+
+  // Auth API — committed BEFORE the queued Firestore writes.
+  await auth.setCustomUserClaims(targetUid, { role: newRole });
+
+  tx.update(userRef, { role: newRole, roleChangedAt: ... });
+  tx.create(auditRef, { actorUid, targetUid, fromRole, toRole, at: ... });
+});
+```
+
+If the claim throws, the queued writes never apply (TX returns before
+commit). If the claim succeeds and the TX commit later fails, the
+claim has already taken effect.
+
+**Trade-offs accepted:**
+
+- **TX retry under contention re-calls `setCustomUserClaims`** with the
+  same payload. Idempotent in practice; minor extra Auth API cost on
+  contention only.
+- **Rate-limit counter doesn't bump on TX-commit failure** even though
+  the claim was set. A small "rate-limit leak" — acceptable because
+  the counter is a soft control against mass-promotion abuse, and the
+  failure path is rare.
+- **Mirror + audit can lag** the actual auth state when a TX commit
+  fails post-claim. Detectable on the next `setUserRole` call; users
+  with a divergent doc will get an audit entry that records the true
+  fromRole on the next role change.
+
+**Alternative considered: TX-first with reconciliation cron.** Run all
+Firestore writes first; call `setCustomUserClaims` after commit. Add
+a scheduled Cloud Function that periodically scans `users/{uid}` for
+claim-vs-mirror divergence and repairs. Rejected because (a) it adds
+production infrastructure and cost, (b) the security gap window
+between TX commit and reconciliation run is unbounded, and (c)
+revocation is the higher-stakes failure mode and should fail closed
+without external dependencies.
+
+**Future hardening (optional).** A `reconcileClaims` scheduled
+function is a defense-in-depth nicety even with claim-first ordering
+— it would catch any drift across either failure direction. With
+claim-first this is forensics; with TX-first it would be a production
+prerequisite.
+
+---
+
+## VII. Security Requirements
 
 **Pattern references:**
 - `security-principles` — least privilege; server-side authorization on every protected op; never trust client role checks; minimize PII.
@@ -146,7 +252,7 @@ Introduce a three-role role-based access control (RBAC) system for Salmoncow. Al
 
 ---
 
-## VII. Firebase Implementation
+## VIII. Firebase Implementation
 
 **Pattern references:**
 - `firebase-best-practices` — users data modeling; Cloud Functions organized by feature; callable pattern with `HttpsError`.
@@ -237,7 +343,7 @@ export const onUserCreate = beforeUserCreated(async (event) => {
 
 ---
 
-## VIII. Testing Requirements
+## IX. Testing Requirements
 
 Per constitution §III.1, auth/authorization is critical path → **100% coverage required**.
 
@@ -259,7 +365,7 @@ Per constitution §III.1, auth/authorization is critical path → **100% coverag
 
 ---
 
-## IX. References
+## X. References
 
 **Constitutional citations:**
 - §II.1 (Security Phase 2 trigger)
@@ -300,9 +406,9 @@ Per constitution §III.1, auth/authorization is critical path → **100% coverag
 
 ---
 
-## X. Technical Implementation Plan
+## XI. Technical Implementation Plan
 
-### X.1 Architecture
+### XI.1 Architecture
 
 **Layering (per `software-architecture` skill + constitution §II.4)**
 
@@ -320,7 +426,7 @@ Per constitution §III.1, auth/authorization is critical path → **100% coverag
 
 **Module budget**: each new module targeted at ≤300 lines (well under §II.3 500-line limit). `AdminPortal.js` web component expected ~250 lines; `admin-user-service.js` ~120; `role.js` ~80.
 
-### X.2 Data Layer
+### XI.2 Data Layer
 
 **Collections** (per `firebase-best-practices`):
 
@@ -347,7 +453,7 @@ rateLimits/setUserRole/actors/{actorUid}
 
 **Indexes**: v1 ships with an empty `firestore.indexes.json`; the single ordered `users` query by `createdAt desc` works on the default index. Add composite only if a new query demands one.
 
-### X.3 UI Components
+### XI.3 UI Components
 
 **Constitution phase: Vanilla Web Components (§II.1 UI).** No framework additions.
 
@@ -363,11 +469,11 @@ rateLimits/setUserRole/actors/{actorUid}
 
 **New view element**: `<div id="adminView" style="display:none">` in `index.html`, populated by `admin-portal.js` controller on route match (follows existing `profileView` pattern in [main.js:109-131](src/main.js)).
 
-### X.4 Security Implementation
+### XI.4 Security Implementation
 
 Covers AC-5, AC-6, AC-7, AC-8, AC-10, AC-14. Skills: `firebase-security`, `security-principles`.
 
-**`firestore.rules` structure** (full sketch in §VII; final file lives at repo root):
+**`firestore.rules` structure** (full sketch in §VIII; final file lives at repo root):
 - Helper fns `isSignedIn`, `roleOf`, `isOwner`, `isAdmin`, `isOwnerOrAdmin`, `isSelf(uid)`.
 - `users/{uid}`:
   - `read`: `isSelf(uid) || isOwnerOrAdmin()`.
@@ -402,7 +508,7 @@ Covers AC-5, AC-6, AC-7, AC-8, AC-10, AC-14. Skills: `firebase-security`, `secur
 **App Check enablement**
 - Enable App Check in the Firebase console with reCAPTCHA Enterprise (web). Wire `initializeAppCheck` in `src/infrastructure/appcheck.js` and invoke from `main.js` after `initializeApp`. Enforce on `setUserRole` via `enforceAppCheck: true`.
 
-### X.5 Testing Strategy
+### XI.5 Testing Strategy
 
 Covers AC-11, AC-12, AC-13. Critical path → 100% coverage per constitution §III.1.
 
@@ -426,7 +532,7 @@ Covers AC-11, AC-12, AC-13. Critical path → 100% coverage per constitution §I
 **CI wiring**
 - Add `.github/workflows/test.yml` running `npm ci && npm run test` in matrix for both root and `functions/`. Gate merges to `main`.
 
-### X.6 Performance / Cost
+### XI.6 Performance / Cost
 
 Per `firebase-cost-resilience` skill + constitution §III.3, §VI.1/VI.2.
 
@@ -450,7 +556,7 @@ Per `firebase-cost-resilience` skill + constitution §III.3, §VI.1/VI.2.
 - Adds Firebase Firestore + Functions SDKs via CDN (same v10.13.2 line). Cached at CDN. Expected uncompressed delta: ~60KB Firestore + ~20KB Functions — acceptable for admin route, which lazy-loads the chunk.
 - `AdminPortal.js` + `admin-portal.js` + `role.js`: ~10KB combined.
 
-### X.7 Implementation Sequencing
+### XI.7 Implementation Sequencing
 
 Ordered to minimize risk and keep `main` shippable at each step. Each numbered block is a prospective commit.
 
@@ -461,7 +567,7 @@ Ordered to minimize risk and keep `main` shippable at each step. Each numbered b
    - Extend `firebase.json` with `firestore`, `functions`, `emulators` blocks.
    - Add `.secrets/` to `.gitignore`.
 2. **Rules (deny-all → role-aware) + tests**
-   - Write real rules per §X.4.
+   - Write real rules per §XI.4.
    - Add `tests/rules/*` with the full matrix (AC-11).
    - Green tests locally via `firebase emulators:exec`.
 3. **Functions + tests**
@@ -494,7 +600,7 @@ Ordered to minimize risk and keep `main` shippable at each step. Each numbered b
     - Branch: `feat/multi-user-rbac`. Title: `feat: introduce three-role RBAC (owner/admin/user)`.
     - Body: Summary, Changes, Testing, Guidance References (§V.1 mandate), Constitutional compliance citations.
 
-### X.8 Files to Create / Modify
+### XI.8 Files to Create / Modify
 
 **New**
 - `firestore.rules`
@@ -538,7 +644,7 @@ Ordered to minimize risk and keep `main` shippable at each step. Each numbered b
 - `.specs/constitution.md` — §II.1 Security row Phase 1→2; §VI.1 Spark→Blaze; bump version + last-updated
 - `.prompts/meta/architectural-decision-log.md` — new Security Phase 2 entry
 
-### X.9 Validation Checklist
+### XI.9 Validation Checklist
 
 - ✅ **Current phase respected**: Vanilla Web Components only (UI Phase 1); first Firestore usage is Simple Collections (Data Phase 1).
 - ✅ **Phase transition justified and documented**: Security Phase 1→2 triggered by the feature's own purpose (custom claims + App Check); decision-log entry included (AC-19).

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1,4 +1,4 @@
 // Cloud Functions entry point for Salmoncow RBAC.
-// Spec: .specs/archive/001-multi-user-rbac/spec.md §X.4
+// Spec: .specs/archive/001-multi-user-rbac/spec.md §XI.4
 export { setUserRole } from './setUserRole.js';
 export { onUserCreate } from './onUserCreate.js';

--- a/functions/src/lib/lastOwnerGuard.ts
+++ b/functions/src/lib/lastOwnerGuard.ts
@@ -1,34 +1,41 @@
+import {
+    type Firestore,
+    type Transaction,
+} from 'firebase-admin/firestore';
 import { HttpsError } from 'firebase-functions/v2/https';
-import { db, type Role } from './admin.js';
+import { type Role } from './admin.js';
 
 /**
  * Refuses role changes that would leave the system with zero owners.
  *
- * Called BEFORE setCustomUserClaims so the claim write doesn't happen on a
- * doomed call. Reads the current owner set via a role==owner query. Has a
- * small TOCTOU window between this check and the claim write; for a hobby
- * admin surface this is acceptable, and the rate limiter caps exposure.
- * Spec §VI.5, §X.4.
+ * Called inside the same `runTransaction` block as the role-change writes,
+ * so the owner-count read shares the lock with the subsequent claim + mirror
+ * writes — no TOCTOU window. The caller has already loaded `currentRole`
+ * via `tx.get(userRef)` upstream, so this helper only needs the count.
+ *
+ * Throws `failed-precondition` if demoting `currentRole === 'owner'` would
+ * drop the owner count to zero.
+ *
+ * Spec: §VI.1 (write ordering, fail-closed revocation).
  */
-export async function assertNotLastOwnerDemotion(
-    targetUid: string,
+export async function assertNotLastOwner(
+    tx: Transaction,
+    db: Firestore,
+    currentRole: Role | null,
     newRole: Role,
 ): Promise<void> {
     if (newRole === 'owner') {
         // Promoting to owner never reduces the owner count.
         return;
     }
-
-    const ownersSnap = await db
-        .collection('users')
-        .where('role', '==', 'owner')
-        .get();
-
-    const isTargetAnOwner = ownersSnap.docs.some((d) => d.id === targetUid);
-    if (!isTargetAnOwner) {
-        // Target isn't currently an owner, so demotion can't reduce the count.
+    if (currentRole !== 'owner') {
+        // Target isn't currently an owner; demotion can't reduce the count.
         return;
     }
+
+    const ownersSnap = await tx.get(
+        db.collection('users').where('role', '==', 'owner'),
+    );
 
     if (ownersSnap.size <= 1) {
         throw new HttpsError(

--- a/functions/src/lib/rateLimit.ts
+++ b/functions/src/lib/rateLimit.ts
@@ -1,69 +1,78 @@
-import { FieldValue, Timestamp } from 'firebase-admin/firestore';
+import {
+    FieldValue,
+    Timestamp,
+    type Firestore,
+    type Transaction,
+} from 'firebase-admin/firestore';
 import { HttpsError } from 'firebase-functions/v2/https';
-import { db } from './admin.js';
 
 /**
  * Fixed-window rate limiter for the setUserRole callable.
  *
  * Stores a counter per actor at:
- *   rateLimits/{action}/actors/{actorUid}
+ *   rateLimits/setUserRole/actors/{actorUid}
+ *
+ * Called inside the parent `runTransaction` block so the counter write is
+ * queued atomically with the role change. If the parent TX commit fails,
+ * the counter doesn't bump — retries aren't penalized.
  *
  * Window resets when the first call of a new hour arrives. Not a true
- * sliding window — acceptable for a hobby admin surface. A compromised
- * owner account can still only issue 20 role changes / hour, capping blast
- * radius. Spec §VI.6, §X.4.
+ * sliding window — acceptable for the admin surface. A compromised owner
+ * account can still only issue 20 role changes / hour, capping blast
+ * radius. Spec §VI.1 (rate-limit-on-failure trade-off).
  */
 
 const WINDOW_MS = 60 * 60 * 1000; // 1 hour
 const MAX_CALLS_PER_WINDOW = 20;
+const ACTION = 'setUserRole';
 
-export async function checkAndIncrementRateLimit(
-    action: string,
+export async function checkAndBumpInTransaction(
+    tx: Transaction,
+    db: Firestore,
     actorUid: string,
 ): Promise<void> {
-    const ref = db.doc(`rateLimits/${action}/actors/${actorUid}`);
+    const ref = db.doc(`rateLimits/${ACTION}/actors/${actorUid}`);
     const now = Date.now();
 
-    await db.runTransaction(async (tx) => {
-        const snap = await tx.get(ref);
-        const data = snap.data();
+    const snap = await tx.get(ref);
+    const data = snap.data();
 
-        if (!data || !data.windowStart) {
-            tx.set(ref, {
-                windowStart: Timestamp.fromMillis(now),
-                count: 1,
-                updatedAt: FieldValue.serverTimestamp(),
-            });
-            return;
-        }
-
-        const windowStartMs: number = (data.windowStart as Timestamp).toMillis();
-        const isStale = now - windowStartMs >= WINDOW_MS;
-
-        if (isStale) {
-            tx.set(ref, {
-                windowStart: Timestamp.fromMillis(now),
-                count: 1,
-                updatedAt: FieldValue.serverTimestamp(),
-            });
-            return;
-        }
-
-        if ((data.count as number) >= MAX_CALLS_PER_WINDOW) {
-            throw new HttpsError(
-                'resource-exhausted',
-                `rate limit exceeded: ${MAX_CALLS_PER_WINDOW} calls per hour`,
-            );
-        }
-
-        tx.update(ref, {
-            count: FieldValue.increment(1),
+    if (!data || !data.windowStart) {
+        tx.set(ref, {
+            windowStart: Timestamp.fromMillis(now),
+            count: 1,
             updatedAt: FieldValue.serverTimestamp(),
         });
+        return;
+    }
+
+    const windowStartMs: number = (data.windowStart as Timestamp).toMillis();
+    const isStale = now - windowStartMs >= WINDOW_MS;
+
+    if (isStale) {
+        tx.set(ref, {
+            windowStart: Timestamp.fromMillis(now),
+            count: 1,
+            updatedAt: FieldValue.serverTimestamp(),
+        });
+        return;
+    }
+
+    if ((data.count as number) >= MAX_CALLS_PER_WINDOW) {
+        throw new HttpsError(
+            'resource-exhausted',
+            `rate limit exceeded: ${MAX_CALLS_PER_WINDOW} calls per hour`,
+        );
+    }
+
+    tx.update(ref, {
+        count: FieldValue.increment(1),
+        updatedAt: FieldValue.serverTimestamp(),
     });
 }
 
 export const __testing__ = {
     WINDOW_MS,
     MAX_CALLS_PER_WINDOW,
+    ACTION,
 };

--- a/functions/src/lib/validate.ts
+++ b/functions/src/lib/validate.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 
 // Input schema for the setUserRole callable. Validated server-side as the
 // single source of truth for what the client is allowed to submit.
-// Spec §VI.3, §X.4.
+// Spec §VII.3, §XI.4.
 export const setUserRoleInput = z.object({
     targetUid: z.string().min(1).max(128),
     role: z.enum(['owner', 'admin', 'user']),

--- a/functions/src/onUserCreate.ts
+++ b/functions/src/onUserCreate.ts
@@ -12,7 +12,7 @@ import { auth, db } from './lib/admin.js';
  * Idempotent: if a users/{uid} doc already exists (rare re-create edge case),
  * the write is a merge that won't stomp an existing role.
  *
- * Spec §VI, §X.4; AC-1.
+ * Spec §VII, §XI.4; AC-1.
  */
 export const onUserCreate = functionsV1.auth.user().onCreate(async (user) => {
     const { uid, email, displayName, photoURL } = user;

--- a/functions/src/setUserRole.ts
+++ b/functions/src/setUserRole.ts
@@ -1,8 +1,8 @@
 import { FieldValue } from 'firebase-admin/firestore';
 import { HttpsError, onCall } from 'firebase-functions/v2/https';
 import { auth, db, type Role } from './lib/admin.js';
-import { assertNotLastOwnerDemotion } from './lib/lastOwnerGuard.js';
-import { checkAndIncrementRateLimit } from './lib/rateLimit.js';
+import { assertNotLastOwner } from './lib/lastOwnerGuard.js';
+import { checkAndBumpInTransaction } from './lib/rateLimit.js';
 import { setUserRoleInput } from './lib/validate.js';
 
 // Production posture: App Check enforced.
@@ -16,21 +16,43 @@ if (process.env.FUNCTIONS_EMULATOR) {
 }
 
 /**
- * setUserRole — owner-only callable that changes a user's role claim + mirror.
+ * setUserRole — owner-only callable that writes a user's role.
  *
- * Defense in depth (spec §VI, §X.4):
- *   1. App Check enforced at the transport layer
- *   2. Auth entry check: context.auth.token.role === 'owner'
- *   3. Zod input validation
- *   4. Rate limit (20 calls / hour / actor)
- *   5. Last-owner guard (no self-lockout)
- *   6. Atomic Firestore TX for doc update + audit entry
+ * Defense in depth (in order):
+ *   1. App Check enforced in production (relaxed under FUNCTIONS_EMULATOR
+ *      so the emulator E2E walkthrough works).
+ *   2. Caller must be authenticated AND have role:'owner' in their
+ *      Firebase ID-token claim.
+ *   3. zod-validated inputs ({ targetUid, role }).
+ *   4. Inside a single Firestore transaction:
+ *      - Target user doc exists.
+ *      - Last-owner guard: cannot demote the only `owner`.
+ *      - Rate limit: ≤20 calls/hour/actor (fixed-window). Counter
+ *        write is queued in this same TX so a failed commit doesn't
+ *        bump the count.
+ *      - **setCustomUserClaims (Auth API)** — called BEFORE the queued
+ *        Firestore writes. The claim is the security boundary that
+ *        Firestore rules read; ordering it ahead of the mirror+audit
+ *        commit gives fail-closed-on-revocation semantics if the TX
+ *        commit later fails. See spec.md §VI Design Decisions for the
+ *        full failure-mode table and rationale.
+ *      - Queued writes: update users/{targetUid} (role + roleChangedAt
+ *        + updatedAt), create audit/{auto}, bump rateLimits counter.
+ *   5. TX commits → all four Firestore writes apply atomically.
+ *
+ * Failure modes (HttpsError codes):
+ *   - permission-denied: caller missing or not owner
+ *   - invalid-argument: bad input
+ *   - not-found: target user doc doesn't exist
+ *   - failed-precondition: would demote last owner
+ *   - resource-exhausted: rate limit hit
+ *
+ * TX retry note: Firestore retries the TX function on contention.
+ * setCustomUserClaims is therefore called once per attempt with the
+ * same payload — idempotent, no security impact, marginal extra Auth
+ * API cost only on contention.
  *
  * Client contract (AC-5, AC-6, AC-7, AC-8):
- *   - permission-denied if caller is not owner
- *   - invalid-argument for malformed input
- *   - resource-exhausted when rate-limited
- *   - failed-precondition when demoting the last owner
  *   - { ok: true, fromRole, toRole } on success
  */
 export const setUserRole = onCall(
@@ -53,40 +75,45 @@ export const setUserRole = onCall(
         }
         const { targetUid, role: toRole } = parsed.data;
 
-        // 3. Rate limit (charges the actor, not the target)
-        await checkAndIncrementRateLimit('setUserRole', callerAuth.uid);
+        const userRef = db.doc(`users/${targetUid}`);
 
-        // 4. Last-owner guard
-        await assertNotLastOwnerDemotion(targetUid, toRole);
+        // 3. Single TX: reads → checks → claim → queued writes.
+        const result = await db.runTransaction(async (tx) => {
+            // Reads first (Firestore TX rule: all reads before any writes).
+            const userSnap = await tx.get(userRef);
+            if (!userSnap.exists) {
+                throw new HttpsError('not-found', `users/${targetUid} not found`);
+            }
+            const fromRole = (userSnap.data()?.role as Role | undefined) ?? null;
 
-        // 5. Read current role for audit metadata
-        const targetSnap = await db.doc(`users/${targetUid}`).get();
-        const fromRole = (targetSnap.data()?.role as Role | undefined) ?? null;
+            await assertNotLastOwner(tx, db, fromRole, toRole);
+            await checkAndBumpInTransaction(tx, db, callerAuth.uid);
 
-        // 6. Set custom claim (propagates on next ID-token refresh)
-        await auth.setCustomUserClaims(targetUid, { role: toRole });
+            // Claim-first: see spec §VI.1 for the full failure-mode rationale.
+            //   - Throws here → queued writes never apply (TX returns
+            //     pre-commit). Safe.
+            //   - Succeeds here, commit fails later → claim is the
+            //     rules-engine source of truth and has already taken
+            //     effect. Fail-closed for revocation. Mirror+audit drift
+            //     is recoverable on retry.
+            await auth.setCustomUserClaims(targetUid, { role: toRole });
 
-        // 7. Atomic mirror update + audit entry
-        await db.runTransaction(async (tx) => {
-            tx.set(
-                db.doc(`users/${targetUid}`),
-                {
-                    role: toRole,
-                    roleChangedAt: FieldValue.serverTimestamp(),
-                    updatedAt: FieldValue.serverTimestamp(),
-                },
-                { merge: true },
-            );
-            const auditRef = db.collection('audit').doc();
-            tx.set(auditRef, {
+            tx.update(userRef, {
+                role: toRole,
+                roleChangedAt: FieldValue.serverTimestamp(),
+                updatedAt: FieldValue.serverTimestamp(),
+            });
+            tx.create(db.collection('audit').doc(), {
                 actorUid: callerAuth.uid,
                 targetUid,
                 fromRole,
                 toRole,
                 at: FieldValue.serverTimestamp(),
             });
+
+            return { fromRole, toRole };
         });
 
-        return { ok: true, fromRole, toRole };
+        return { ok: true, ...result };
     },
 );

--- a/functions/tests/onUserCreate.test.ts
+++ b/functions/tests/onUserCreate.test.ts
@@ -4,7 +4,7 @@ import { auth, db } from '../src/lib/admin.js';
 import { clearFirestore, ensureAuthUser, ft, nextUid } from './helpers.js';
 
 // Acceptance criteria: AC-1, AC-12
-// Spec §X.4 (trigger shape)
+// Spec §XI.4 (trigger shape)
 
 const wrapped = ft.wrap(onUserCreate);
 

--- a/functions/tests/setUserRole.test.ts
+++ b/functions/tests/setUserRole.test.ts
@@ -7,7 +7,7 @@ import { auth, db } from '../src/lib/admin.js';
 import { clearFirestore, ensureAuthUser, ft, nextUid } from './helpers.js';
 
 // Acceptance criteria: AC-5, AC-6, AC-7, AC-8, AC-12
-// Spec §VI (security), §X.4 (callable shape)
+// Spec §VII (security), §XI.4 (callable shape)
 
 const wrapped = ft.wrap(setUserRole);
 

--- a/src/components/AdminPortal.js
+++ b/src/components/AdminPortal.js
@@ -17,7 +17,7 @@
  *   - role-change: { detail: { targetUid, toRole } }
  *   - page-request: fired when "Load more" is clicked
  *
- * Spec §X.3 (UI), AC-3, AC-4, AC-15
+ * Spec §XI.3 (UI), AC-3, AC-4, AC-15
  */
 
 const ROLE_LABEL = Object.freeze({

--- a/src/factories/repository-factory.js
+++ b/src/factories/repository-factory.js
@@ -4,7 +4,7 @@
  * Constructs repository instances wired to Firestore. The localStorage
  * implementation was retired when the project adopted Firestore as the
  * source of truth for the users collection — see
- * .specs/archive/001-multi-user-rbac/spec.md §X.1, §X.2.
+ * .specs/archive/001-multi-user-rbac/spec.md §XI.1, §XI.2.
  *
  * Local dev uses the Firestore emulator (wired automatically by
  * src/infrastructure/firestore.js). Developer setup: run `npm run dev`

--- a/src/infrastructure/appcheck.js
+++ b/src/infrastructure/appcheck.js
@@ -8,7 +8,7 @@
  *   under FUNCTIONS_EMULATOR (see functions/src/setUserRole.ts).
  * - In prod: initializes reCAPTCHA Enterprise using the site key from env.
  *
- * Spec §VI, §X.4 (App Check enforcement on setUserRole)
+ * Spec §VII, §XI.4 (App Check enforcement on setUserRole)
  */
 import {
     initializeAppCheck,

--- a/src/infrastructure/emulator.js
+++ b/src/infrastructure/emulator.js
@@ -6,7 +6,7 @@
  * Firebase project. Detection is purely env-based, no runtime hostname
  * sniffing, so the behavior is predictable in CI and tests.
  *
- * Spec §X.1, §X.4
+ * Spec §XI.1, §XI.4
  */
 
 const isDev = import.meta.env.DEV === true;

--- a/src/infrastructure/firestore.js
+++ b/src/infrastructure/firestore.js
@@ -5,7 +5,7 @@
  * the raw `db` for repositories + an `onSnapshotDoc` helper that returns
  * an unsubscribe function (for predictable cleanup).
  *
- * Spec §X.1 (infrastructure layer)
+ * Spec §XI.1 (infrastructure layer)
  */
 import {
     connectFirestoreEmulator,

--- a/src/infrastructure/functions.js
+++ b/src/infrastructure/functions.js
@@ -5,7 +5,7 @@
  * `callable(name)` helper returns a pre-configured httpsCallable function
  * tied to the default region (us-central1 unless overridden in firebase.json).
  *
- * Spec §X.1, §X.4 (callable entry)
+ * Spec §XI.1, §XI.4 (callable entry)
  */
 import {
     connectFunctionsEmulator,

--- a/src/modules/admin-portal.js
+++ b/src/modules/admin-portal.js
@@ -9,7 +9,7 @@
  *   - Role-observable subscription so the component re-renders when the
  *     current user's own role changes (e.g. owner gets demoted)
  *
- * Spec §X.3, §X.7 Group 7; AC-3, AC-4, AC-9, AC-15
+ * Spec §XI.3, §XI.7 Group 7; AC-3, AC-4, AC-9, AC-15
  */
 
 export class AdminPortalModule {

--- a/src/modules/role.js
+++ b/src/modules/role.js
@@ -13,7 +13,7 @@
  * onUserCreate fires, or a token that never got a claim). Matches Firestore
  * rules, which treat missing role as least-privilege.
  *
- * Spec §X.1 (application layer), AC-2, AC-9
+ * Spec §XI.1 (application layer), AC-2, AC-9
  */
 import {
     doc,

--- a/src/repositories/firestore-user-profile-repository.js
+++ b/src/repositories/firestore-user-profile-repository.js
@@ -9,7 +9,7 @@
  * field out of incoming update payloads as defense in depth so failures
  * happen before the network round-trip.
  *
- * Spec §VI (security), §X.2 (data layer), §X.4
+ * Spec §VII (security), §XI.2 (data layer), §XI.4
  */
 import {
     collection,

--- a/src/services/admin-user-service.js
+++ b/src/services/admin-user-service.js
@@ -10,7 +10,7 @@
  * 2. Translate callable HttpsError codes into the Result shape the rest of
  *    the client uses, so the UI can render friendly messages.
  *
- * Spec §X.3, §X.4; AC-3, AC-15
+ * Spec §XI.3, §XI.4; AC-3, AC-15
  */
 
 import { callable } from '../infrastructure/functions.js';


### PR DESCRIPTION
Brings the salmoncow `setUserRole` implementation into alignment with the production-level pattern landed in citl after a security review, and ports back the self-contained **§VI Design Decisions** spec section the citl session authored.

## Summary

- The original salmoncow `setUserRole` realized claim-first ordering by calling `setCustomUserClaims` *outside* the `runTransaction` block — and ran the rate-limit bump and last-owner check as separate operations before the main TX. The intent was right; the structure had a TOCTOU window in last-owner detection and debited the rate-limit counter even on TX failure.
- Citl's session refactored to a single TX that does reads + checks + claim + queued writes under one lock. This PR brings salmoncow into structural parity.
- §VI Design Decisions is ported verbatim (the section was deliberately authored to be portable). Causes a renumber cascade for the rest of the spec.

## Two atomic commits

| Commit | Concern |
|---|---|
| `307b178 refactor(rbac): unify setUserRole into single TX with claim-first ordering` | Load-bearing behavior change. Helper signatures change; setUserRole body reorganized; existing tests (18/18) pass without assertion changes. |
| `081c5a3 docs(rbac): port §VI Design Decisions from citl + renumber spec sections` | Spec insert + cascade renumber + 15 code-comment ref updates pointing at the new section numbers. Zero functional impact. |

## Behavior delta vs. previous implementation

| Concern | Was | Now |
|---|---|---|
| Reads of target user + owner set | Outside TX (race-prone) | Inside TX via `tx.get()` (consistent under lock) |
| Existence check | None | `tx.get()` throws `not-found` if doc absent |
| Last-owner guard | Separate query before TX | Inside TX, owner-set query under lock |
| Rate-limit bump | Own TX, debited regardless | Queued in main TX, only commits on success |
| `setCustomUserClaims` | Before `runTransaction` opens | Inside TX function, before queued writes |
| Audit write | `tx.set` | `tx.create` (matches intent for auto-id) |
| User write | `tx.set(..., {merge:true})` | `tx.update(...)` (existence pre-checked) |

Failure semantics preserved (and tightened): claim-first still gives fail-closed revocation. The TOCTOU window the previous lastOwnerGuard docstring acknowledged is now closed.

## Testing

- [x] `cd functions && npm run build` — TypeScript clean
- [x] `npm run test:functions` — 18/18 green (11 setUserRole + 3 onUserCreate + 5 App Check source-level regression guards)
- [x] No test assertion changes needed; existing seed helpers + behavioral assertions cover the new structure as-is
- [x] Final sweep `grep -rn '§X\.' functions/ src/` (excluding archive) returns empty
- [x] Spec section count: 11 (I through XI), continuous

## Drift parking lot (unchanged in this PR; flagged)

- `lastOwnerGuard.ts` previously documented a TOCTOU window. The new helper closes it; docstring updated.
- Salmoncow's spec §VII Security Requirements (renamed from §VI in this PR) and citl's spec have parallel-but-different security-requirement coverage. Not harmonized in this PR — citl distributes those concerns across its §VI Design Decisions and implementation plan rather than having a parallel §VII.
- `setUserRoleInput` zod schema in salmoncow vs. citl: both projects use the same shape (`{ targetUid: string, role: 'owner'|'admin'|'user' }`). Verified parity is intentional, not coincidental.

## Constitutional compliance

- §III.1 critical-path coverage: 18/18 tests pass; structural change preserves coverage
- §III.2 server-side authz: every protected op still server-side; rules unchanged
- §IV.2 forbidden patterns: no client-side filtering, no unbounded reads introduced
- §V.1 PR format: this body